### PR TITLE
Don't set success_redirect = '/' by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v1.2.1]
+
+### Added
+- Removed default setting of `success_redirect = '/'` in RpiAuth config
+
+## [v1.2.0]
+
+### Added
+- omniauth-rpi gem updated to fix nil user ID in returned user object
+
 ## [v1.0.0]
 
 ### Added

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 PATH
   remote: .
   specs:
-    rpi_auth (1.1.0)
+    rpi_auth (1.2.1)
       omniauth-rails_csrf_protection (~> 1.0.0)
-      omniauth-rpi (~> 1.3.2)
+      omniauth-rpi (~> 1.4.0)
       rails (>= 6.1.4)
 
 GEM
@@ -83,7 +83,7 @@ GEM
     diff-lcs (1.5.0)
     docile (1.4.0)
     erubi (1.11.0)
-    faraday (2.7.1)
+    faraday (2.7.4)
       faraday-net_http (>= 2.0, < 3.1)
       ruby2_keywords (>= 0.0.4)
     faraday-net_http (3.0.2)
@@ -128,7 +128,7 @@ GEM
       rack (>= 1.2, < 4)
       snaky_hash (~> 2.0)
       version_gem (~> 1.1)
-    omniauth (2.1.0)
+    omniauth (2.1.1)
       hashie (>= 3.4.6)
       rack (>= 2.2.3)
       rack-protection
@@ -138,7 +138,7 @@ GEM
     omniauth-rails_csrf_protection (1.0.1)
       actionpack (>= 4.2)
       omniauth (~> 2.0)
-    omniauth-rpi (1.3.2)
+    omniauth-rpi (1.4.0)
       jwt (~> 2.2.3)
       omniauth (~> 2.0)
       omniauth-oauth2 (~> 1.4)
@@ -153,7 +153,7 @@ GEM
       pry (>= 0.13, < 0.15)
     racc (1.6.2)
     rack (2.2.4)
-    rack-protection (3.0.4)
+    rack-protection (3.0.5)
       rack
     rack-test (2.0.2)
       rack (>= 1.3)

--- a/app/controllers/rpi_auth/auth_controller.rb
+++ b/app/controllers/rpi_auth/auth_controller.rb
@@ -2,6 +2,7 @@
 
 module RpiAuth
   class AuthController < ApplicationController
+    # rubocop:disable Metrics/AbcSize
     def callback
       # Prevent session fixation. If the session has been initialized before
       # this, and we need to keep the data, then we should copy values over.
@@ -18,6 +19,7 @@ module RpiAuth
       end
 
       redirect_to '/'
+      # rubocop:enable Metrics/AbcSize
     end
 
     def destroy

--- a/app/controllers/rpi_auth/auth_controller.rb
+++ b/app/controllers/rpi_auth/auth_controller.rb
@@ -11,12 +11,10 @@ module RpiAuth
       user = RpiAuth.user_model.from_omniauth(auth)
       session[:current_user] = user
 
-      if RpiAuth.configuration.success_redirect
-        return redirect_to RpiAuth.configuration.success_redirect
-      end
+      return redirect_to RpiAuth.configuration.success_redirect if RpiAuth.configuration.success_redirect
 
       if request.env.key?('omniauth.origin') && request.env['omniauth.origin'].present?
-        return redirect_to(request.env['omniauth.origin'], allow_other_host: false) 
+        return redirect_to(request.env['omniauth.origin'], allow_other_host: false)
       end
 
       redirect_to '/'

--- a/lib/rpi_auth/configuration.rb
+++ b/lib/rpi_auth/configuration.rb
@@ -14,7 +14,6 @@ module RpiAuth
                   :user_model
 
     def initialize
-      @success_redirect = '/'
       @bypass_auth = false
     end
   end

--- a/lib/rpi_auth/version.rb
+++ b/lib/rpi_auth/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module RpiAuth
-  VERSION = '1.2.0'
+  VERSION = '1.2.1'
 end

--- a/spec/dummy/config/initializers/rpi_auth.rb
+++ b/spec/dummy/config/initializers/rpi_auth.rb
@@ -6,7 +6,6 @@ if Rails.env.development?
     config.host_url = 'http://localhost:3009'
     config.identity_url = 'http://localhost:3002'
     config.user_model = 'User'
-    config.success_redirect = '/'
     config.bypass_auth = false
   end
 end
@@ -19,7 +18,6 @@ if Rails.env.test?
     config.host_url = 'https://fakepi.com'
     config.identity_url = 'https://my.fakepi.com'
     config.user_model = 'User'
-    config.success_redirect = '/'
     config.bypass_auth = true
   end
 end


### PR DESCRIPTION
It should generally be allowed to default to the `omniauth.origin` value (which ensures that the user is returned to the page at which they made the request): https://github.com/RaspberryPiFoundation/rpi-auth/blob/37ac1d441498a3e56c6431c880e4d054cd108695/app/controllers/rpi_auth/auth_controller.rb#L14-L20