### PR TITLE
fix(Authenticatable-model): access from_omniauth via User model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,27 +1,38 @@
 # Changelog
+
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v1.3.0]
+
+### Added
+
+- Make `RpiAuth::Models::Authenticatable` extendable to support additional methods and attributes in the `user_model`.
+
 ## [v1.2.1]
 
 ### Added
+
 - Removed default setting of `success_redirect = '/'` in RpiAuth config
 
 ## [v1.2.0]
 
 ### Added
+
 - omniauth-rpi gem updated to fix nil user ID in returned user object
 
 ## [v1.0.0]
 
 ### Added
+
 - Rails 7 / Ruby 3.1 support (these are the only officially supported versions)
 
 ## [Unreleased]
 
 ### Added
+
 - omniauth-rpi strategy to auth via Hydra1
 - include omniauth rails csrf protection
 - configuration to allow setting endpoints and credentials for auth

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rpi_auth (1.2.1)
+    rpi_auth (1.3.0)
       omniauth-rails_csrf_protection (~> 1.0.0)
       omniauth-rpi (~> 1.4.0)
       rails (>= 6.1.4)
@@ -246,7 +246,7 @@ GEM
     tzinfo (2.0.5)
       concurrent-ruby (~> 1.0)
     unicode-display_width (2.3.0)
-    version_gem (1.1.1)
+    version_gem (1.1.2)
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)

--- a/README.md
+++ b/README.md
@@ -7,13 +7,15 @@ A gem to handle authenticating via Hydra for Raspberry Pi Foundation Rails appli
 The Engine includes the [Rails CSRF protection gem](https://github.com/cookpad/omniauth-rails_csrf_protection), so this does not need to be included in the parent application
 
 ## Installation
+
 Add this line to your application's Gemfile:
 
 ```ruby
-gem 'rpi_auth', git: 'https://github.com/RaspberryPiFoundation/rpi-auth.git', tag: 'v1.0.1'
+gem 'rpi_auth', git: 'https://github.com/RaspberryPiFoundation/rpi-auth.git', tag: 'v1.3.0'
 ```
 
 And then execute:
+
 ```bash
 $ bundle
 ```
@@ -23,7 +25,7 @@ Add an initializer file to configure rpi_auth e.g. in `config/initializers/rpi_a
 ```ruby
 RpiAuth.configure do |config|
   config.auth_url = 'http://localhost:9000'            # The url of Hydra being used
-  config.auth_token_url = nil                          # Normally this would be unset, defaulting to AUTH_URL above. When running locally under Docker, set to http://host.docker.internal:9001 
+  config.auth_token_url = nil                          # Normally this would be unset, defaulting to AUTH_URL above. When running locally under Docker, set to http://host.docker.internal:9001
   config.auth_client_id = 'gem-dev'                    # The Hydra client ID
   config.auth_client_secret = 'secret'                 # The Hydra client secret
   config.host_url = 'http://localhost:3009'            # The url of the host site used (needed for redirects)
@@ -68,7 +70,7 @@ Add the `authenticatable` concern to the host application's User model:
 
 ```ruby
 class User < ApplicationRecord
-  include RpiAuth::Models::Authenticatable
+  extend RpiAuth::Models::Authenticatable
 end
 ```
 
@@ -108,14 +110,17 @@ There is a helper for the logout route:
 ```
 
 ## License
+
 The gem is available as open source under the terms of the [MIT License](https://opensource.org/licenses/MIT).
 
 ## Local Development
 
 Run:
+
 ```bash
 $ bundle
 ```
+
 from the root directory. This will also install the gems required by the dummy application found at `spec/dummy`.
 
 The dummy app can be interacted with in the same way as any Rails application. Go into `spec/dummy` and run commands as normal.
@@ -128,6 +133,7 @@ This port matches that set in `spec/dummy/config/initializers/rpi_auth.rb` and w
 There is a simple page at the dummy app root that has a login link and will show a logout link once logged in via Hydra.
 
 If running Hydra locally you will need to configure a new client with the following values:
+
 ```ruby
 {
   id: 'gem-dev',
@@ -135,6 +141,7 @@ If running Hydra locally you will need to configure a new client with the follow
   redirect_urls: 'http://localhost:3009/rpi_auth/auth/callback'
 }
 ```
+
 There is a seed in the Profile repo to set this client up correctly, running the v1 setup tasks will create this client
 
 Ensure to update `lib/rpi_auth/version.rb` when publishing a new version.
@@ -147,4 +154,3 @@ This Gem should work with Rails 6.1+, but the `Gemfile.lock` is tracking Rails 7
 bundle install --gemfile gemfiles/rails_6.1.gemfile
 bundle exec --gemfile gemfiles/rails_6.1.gemfile rspec
 ```
-

--- a/app/controllers/rpi_auth/auth_controller.rb
+++ b/app/controllers/rpi_auth/auth_controller.rb
@@ -2,6 +2,8 @@
 
 module RpiAuth
   class AuthController < ApplicationController
+    protect_from_forgery with: :null_session
+
     # rubocop:disable Metrics/AbcSize
     def callback
       # Prevent session fixation. If the session has been initialized before

--- a/lib/rpi_auth/models/authenticatable.rb
+++ b/lib/rpi_auth/models/authenticatable.rb
@@ -26,15 +26,13 @@ module RpiAuth
         (['user_id'] + PROFILE_KEYS).index_with { |_k| nil }
       end
 
-      class_methods do
-        def from_omniauth(auth)
-          return nil unless auth
+      def from_omniauth(auth)
+        return nil unless auth
 
-          args = auth.extra.raw_info.to_h.slice(*PROFILE_KEYS)
-          args['user_id'] = auth.uid
+        args = auth.extra.raw_info.to_h.slice(*PROFILE_KEYS)
+        args['user_id'] = auth.uid
 
-          new(args)
-        end
+        new(args)
       end
     end
   end

--- a/spec/dummy/app/models/user.rb
+++ b/spec/dummy/app/models/user.rb
@@ -1,3 +1,3 @@
 class User
-  include RpiAuth::Models::Authenticatable
+  extend RpiAuth::Models::Authenticatable
 end

--- a/spec/requests/auth_request_spec.rb
+++ b/spec/requests/auth_request_spec.rb
@@ -2,6 +2,10 @@
 
 require 'spec_helper'
 
+class DummyUser
+  extend RpiAuth::Models::Authenticatable
+end
+
 RSpec.describe 'Authentication' do
   let(:user) do
     {
@@ -17,6 +21,15 @@ RSpec.describe 'Authentication' do
   let(:bypass_oauth) { '' }
   let(:identity_url) { 'https://my.fakepi.com' }
   let(:host_url) { 'https://fakepi.com' }
+
+  before do
+    RpiAuth.configuration.user_model = 'DummyUser'
+  end
+
+  after do
+    # Reset value or it affects other tests :(
+    RpiAuth.configuration.user_model = 'User'
+  end
 
   describe 'GET /rpi_auth/logout' do
     before do

--- a/spec/rpi_auth/models/authenticatable_spec.rb
+++ b/spec/rpi_auth/models/authenticatable_spec.rb
@@ -3,7 +3,7 @@
 require 'spec_helper'
 
 class DummyUser
-  include RpiAuth::Models::Authenticatable
+  extend RpiAuth::Models::Authenticatable
 end
 
 RSpec.describe DummyUser, type: :model do

--- a/spec/rpi_auth_spec.rb
+++ b/spec/rpi_auth_spec.rb
@@ -3,7 +3,7 @@
 require 'spec_helper'
 
 class DummyUser
-  include RpiAuth::Models::Authenticatable
+  extend RpiAuth::Models::Authenticatable
 end
 
 RSpec.describe RpiAuth do


### PR DESCRIPTION
Allow `Authenticatable` to be extendable, giving access to custom methods and attributes without having to change the base module.