### PR TITLE
Specify log out URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v1.5.0]
+
+### Added
+
+- The `log_out_url` config var can now optionally be set (eg. to the appropriate /oauth2/sessions/logout endpoint once the app's session has been destroyed)
+
+Reference notes: https://github.com/RaspberryPiFoundation/documentation/blob/main/accounts/hydra-v1/logging-out.md
+
 ## [v1.4.0]
 
 ### Added

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rpi_auth (1.3.0)
+    rpi_auth (1.5.0)
       omniauth-rails_csrf_protection (~> 1.0.0)
       omniauth-rpi (~> 1.4.0)
       rails (>= 6.1.4)
@@ -153,7 +153,7 @@ GEM
       pry (>= 0.13, < 0.15)
     racc (1.6.2)
     rack (2.2.4)
-    rack-protection (3.0.5)
+    rack-protection (3.0.6)
       rack
     rack-test (2.0.2)
       rack (>= 1.3)

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Add an initializer file to configure rpi_auth e.g. in `config/initializers/rpi_a
 
 ```ruby
 RpiAuth.configure do |config|
-  config.auth_url = 'http://localhost:9000'                           # The url of Hydra being used
+  config.auth_url = 'http://localhost:9001'                           # The url of Hydra being used
   config.auth_token_url = nil                                         # Normally this would be unset, defaulting to AUTH_URL above. When running locally under Docker, set to http://host.docker.internal:9001
   config.auth_client_id = 'gem-dev'                                   # The Hydra client ID
   config.auth_client_secret = 'secret'                                # The Hydra client secret

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ RpiAuth.configure do |config|
   config.auth_client_id = 'gem-dev'                                   # The Hydra client ID
   config.auth_client_secret = 'secret'                                # The Hydra client secret
   config.brand = 'brand-name'                                         # The brand of the application (see allowed brands in Profile application: app/middleware/brand.js)
-  config.host_url = 'http://localhost:3009'                           # The url of the host site used (needed for redirects)
+  config.host_url = 'http://localhost:3000'                           # The url of the host site used (needed for redirects)
   config.identity_url = 'http://localhost:3002'                       # The url for the profile instance being used for auth
   config.log_out_url = 'http://localhost:9001/oauth2/sessions/logout' # The url for the log out path (usually the /oauth2/sessions/logout path of the OAuth provider)
   config.user_model = 'User'                                          # The name of the user model in the host app being used, use the name as a string, not the model itself

--- a/README.md
+++ b/README.md
@@ -24,17 +24,18 @@ Add an initializer file to configure rpi_auth e.g. in `config/initializers/rpi_a
 
 ```ruby
 RpiAuth.configure do |config|
-  config.auth_url = 'http://localhost:9000'            # The url of Hydra being used
-  config.auth_token_url = nil                          # Normally this would be unset, defaulting to AUTH_URL above. When running locally under Docker, set to http://host.docker.internal:9001
-  config.auth_client_id = 'gem-dev'                    # The Hydra client ID
-  config.auth_client_secret = 'secret'                 # The Hydra client secret
-  config.brand = 'brand-name'                          # The brand of the application (see allowed brands in Profile application: app/middleware/brand.js)
-  config.host_url = 'http://localhost:3009'            # The url of the host site used (needed for redirects)
-  config.identity_url = 'http://localhost:3002'        # The url for the profile instance being used for auth
-  config.user_model = 'User'                           # The name of the user model in the host app being used, use the name as a string, not the model itself
-  config.scope = 'openid email profile force-consent'  # The required OIDC scopes
-  config.success_redirect = '/'                        # After succesful login the route the user should be redirected to; this will override redirecting the user back to where they were when they started the log in / sign up flow (via `omniauth.origin`), so should be used rarely / with caution
-  config.bypass_auth = false                           # Should auth be bypassed and a default user logged in
+  config.auth_url = 'http://localhost:9000'                           # The url of Hydra being used
+  config.auth_token_url = nil                                         # Normally this would be unset, defaulting to AUTH_URL above. When running locally under Docker, set to http://host.docker.internal:9001
+  config.auth_client_id = 'gem-dev'                                   # The Hydra client ID
+  config.auth_client_secret = 'secret'                                # The Hydra client secret
+  config.brand = 'brand-name'                                         # The brand of the application (see allowed brands in Profile application: app/middleware/brand.js)
+  config.host_url = 'http://localhost:3009'                           # The url of the host site used (needed for redirects)
+  config.identity_url = 'http://localhost:3002'                       # The url for the profile instance being used for auth
+  config.log_out_url = 'http://localhost:9001/oauth2/sessions/logout' # The url for the log out path (usually the /oauth2/sessions/logout path of the OAuth provider)
+  config.user_model = 'User'                                          # The name of the user model in the host app being used, use the name as a string, not the model itself
+  config.scope = 'openid email profile force-consent'                 # The required OIDC scopes
+  config.success_redirect = '/'                                       # After succesful login the route the user should be redirected to; this will override redirecting the user back to where they were when they started the log in / sign up flow (via `omniauth.origin`), so should be used rarely / with caution
+  config.bypass_auth = false                                          # Should auth be bypassed and a default user logged in
 end
 ```
 
@@ -51,6 +52,7 @@ RpiAuth.configure do |config|
   config.brand = 'brand-name'
   config.host_url = ENV.fetch('HOST_URL', nil)
   config.identity_url = ENV.fetch('IDENTITY_URL', nil)
+  config.log_out_url = ENV.fetch('LOG_OUT_URL', nil)
   config.user_model = 'User'
   config.scope = 'openid email profile force-consent'
   config.success_redirect = ENV.fetch('OAUTH_SUCCESS_REDIRECT_URL', nil)
@@ -147,6 +149,12 @@ If running Hydra locally you will need to configure a new client with the follow
 There is a seed in the Profile repo to set this client up correctly, running the v1 setup tasks will create this client
 
 Ensure to update `lib/rpi_auth/version.rb` when publishing a new version.
+
+### Testing
+
+```bash
+$ bundle exec rspec
+```
 
 ### Testing with different versions of Rails
 

--- a/app/controllers/rpi_auth/auth_controller.rb
+++ b/app/controllers/rpi_auth/auth_controller.rb
@@ -33,6 +33,11 @@ module RpiAuth
         return
       end
 
+      if RpiAuth.configuration.log_out_url
+        redirect_to RpiAuth.configuration.log_out_url, allow_other_host: true
+        return
+      end
+
       redirect_to "#{RpiAuth.configuration.identity_url}/logout?returnTo=#{RpiAuth.configuration.host_url}",
                   allow_other_host: true
     end

--- a/lib/rpi_auth/configuration.rb
+++ b/lib/rpi_auth/configuration.rb
@@ -10,6 +10,7 @@ module RpiAuth
                   :bypass_auth,
                   :host_url,
                   :identity_url,
+                  :log_out_url,
                   :scope,
                   :success_redirect,
                   :user_model

--- a/lib/rpi_auth/version.rb
+++ b/lib/rpi_auth/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module RpiAuth
-  VERSION = '1.4.0'
+  VERSION = '1.5.0'
 end

--- a/spec/dummy/config/initializers/rpi_auth.rb
+++ b/spec/dummy/config/initializers/rpi_auth.rb
@@ -13,12 +13,12 @@ end
 
 if Rails.env.test?
   RpiAuth.configure do |config|
-    config.auth_url = 'http://fakeauth.com'
+    config.auth_url = 'http://auth.example.com'
     config.auth_client_id = 'clientid'
     config.auth_client_secret = 'clientsecret'
     config.brand = 'codeclub'
-    config.host_url = 'https://fakepi.com'
-    config.identity_url = 'https://my.fakepi.com'
+    config.host_url = 'https://example.com'
+    config.identity_url = 'https://my.example.com'
     config.user_model = 'User'
     config.bypass_auth = true
   end

--- a/spec/requests/auth_request_spec.rb
+++ b/spec/requests/auth_request_spec.rb
@@ -34,6 +34,7 @@ RSpec.describe 'Authentication' do
   describe 'GET /rpi_auth/logout' do
     before do
       RpiAuth.configuration.bypass_auth = false
+      RpiAuth.configuration.log_out_url = nil
       sign_in(user)
     end
 
@@ -48,7 +49,7 @@ RSpec.describe 'Authentication' do
       expect(session['current_user']).to be_nil
     end
 
-    it 'clears the current session and redirects to specified log out endpoint' do
+    it 'clears the current session and redirects to a specified log out endpoint' do
       RpiAuth.configuration.log_out_url = 'https://auth.example.com/oauth2/sessions/logout'
       expect(session['current_user']).not_to be_nil
       previous_id = session.id

--- a/spec/requests/auth_request_spec.rb
+++ b/spec/requests/auth_request_spec.rb
@@ -19,8 +19,8 @@ RSpec.describe 'Authentication' do
     }
   end
   let(:bypass_oauth) { '' }
-  let(:identity_url) { 'https://my.fakepi.com' }
-  let(:host_url) { 'https://fakepi.com' }
+  let(:identity_url) { 'https://my.example.com' }
+  let(:host_url) { 'https://example.com' }
 
   before do
     RpiAuth.configuration.user_model = 'DummyUser'
@@ -44,6 +44,18 @@ RSpec.describe 'Authentication' do
       get '/rpi_auth/logout'
 
       expect(response).to redirect_to("#{identity_url}/logout?returnTo=#{host_url}")
+      expect(session.id).not_to eq previous_id
+      expect(session['current_user']).to be_nil
+    end
+
+    it 'clears the current session and redirects to specified log out endpoint' do
+      RpiAuth.configuration.log_out_url = 'https://auth.example.com/oauth2/sessions/logout'
+      expect(session['current_user']).not_to be_nil
+      previous_id = session.id
+
+      get '/rpi_auth/logout'
+
+      expect(response).to redirect_to('https://auth.example.com/oauth2/sessions/logout')
       expect(session.id).not_to eq previous_id
       expect(session['current_user']).to be_nil
     end


### PR DESCRIPTION
Related to:
* https://github.com/RaspberryPiFoundation/profile/pull/1374
* https://github.com/RaspberryPiFoundation/profile/pull/1376

Allows for a log out URL to be specified, this should in most cases be the OAuth / Open ID service's `/oauth2/sessions/logout` endpoint.

***

Considerations:
* Should we just default to `//auth/oauth2/sessions/logout`? (rather than [Profile's log out](https://github.com/RaspberryPiFoundation/rpi-auth/pull/45/files#diff-6dc2d00d8e3d3d41c4398392c4ffbc247dd8bc450ea9a549fcab10de9a921d90R41) as is currently set)
* Is the current default `//profile/logout` actually preferable, since it'll now redirect to `//auth/oauth2/sessions/logout` anyway? (and will also honour the `returnTo` param, as in `//profile/logout?returnTo=https://codeclub.org`, whereas `//auth/oauth2/sessions/logout?returnTo=https://codeclub.org` won't return)