### PR TITLE
Use omniauth openid connect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Replaced usage of [omniauth-rpi](https://github.com/RaspberryPiFoundation/omniauth-rpi/) strategy with [omniauth_openid_connect](https://github.com/omniauth/omniauth_openid_connect/) (#51)
+
 ## [v2.0.0]
 
 ### Added

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -163,6 +163,8 @@ GEM
       byebug (~> 11.0)
       pry (>= 0.13, < 0.15)
     public_suffix (5.0.1)
+    puma (6.2.2)
+      nio4r (~> 2.0)
     racc (1.6.2)
     rack (2.2.7)
     rack-oauth2 (2.2.0)
@@ -289,6 +291,7 @@ PLATFORMS
 DEPENDENCIES
   listen
   pry-byebug
+  puma
   rails (~> 7.0)
   rpi_auth!
   rspec-rails

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     rpi_auth (2.0.0)
       omniauth-rails_csrf_protection (~> 1.0.0)
-      omniauth-rpi (~> 1.4.0)
+      omniauth_openid_connect (~> 0.7.1)
       rails (>= 6.1.4)
 
 GEM
@@ -74,7 +74,10 @@ GEM
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
       tzinfo (~> 2.0)
+    aes_key_wrap (1.1.0)
     ast (2.4.2)
+    attr_required (1.0.1)
+    bindata (2.4.15)
     builder (3.2.4)
     byebug (11.1.3)
     coderay (1.1.3)
@@ -86,6 +89,8 @@ GEM
     faraday (2.7.4)
       faraday-net_http (>= 2.0, < 3.1)
       ruby2_keywords (>= 0.0.4)
+    faraday-follow_redirects (0.3.0)
+      faraday (>= 1, < 3)
     faraday-net_http (3.0.2)
     ffi (1.15.5)
     globalid (1.1.0)
@@ -94,7 +99,12 @@ GEM
     i18n (1.13.0)
       concurrent-ruby (~> 1.0)
     json (2.6.2)
-    jwt (2.2.3)
+    json-jwt (1.16.3)
+      activesupport (>= 4.2)
+      aes_key_wrap
+      bindata
+      faraday (~> 2.0)
+      faraday-follow_redirects
     listen (3.7.1)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
@@ -107,7 +117,6 @@ GEM
     method_source (1.0.0)
     mini_mime (1.1.2)
     minitest (5.18.0)
-    multi_xml (0.6.0)
     net-imap (0.3.1)
       net-protocol
     net-pop (0.1.2)
@@ -121,27 +130,29 @@ GEM
       racc (~> 1.4)
     nokogiri (1.14.3-x86_64-linux)
       racc (~> 1.4)
-    oauth2 (2.0.9)
-      faraday (>= 0.17.3, < 3.0)
-      jwt (>= 1.0, < 3.0)
-      multi_xml (~> 0.5)
-      rack (>= 1.2, < 4)
-      snaky_hash (~> 2.0)
-      version_gem (~> 1.1)
     omniauth (2.1.1)
       hashie (>= 3.4.6)
       rack (>= 2.2.3)
       rack-protection
-    omniauth-oauth2 (1.8.0)
-      oauth2 (>= 1.4, < 3)
-      omniauth (~> 2.0)
     omniauth-rails_csrf_protection (1.0.1)
       actionpack (>= 4.2)
       omniauth (~> 2.0)
-    omniauth-rpi (1.4.0)
-      jwt (~> 2.2.3)
-      omniauth (~> 2.0)
-      omniauth-oauth2 (~> 1.4)
+    omniauth_openid_connect (0.7.1)
+      omniauth (>= 1.9, < 3)
+      openid_connect (~> 2.2)
+    openid_connect (2.2.0)
+      activemodel
+      attr_required (>= 1.0.0)
+      faraday (~> 2.0)
+      faraday-follow_redirects
+      json-jwt (>= 1.16)
+      net-smtp
+      rack-oauth2 (~> 2.2)
+      swd (~> 2.0)
+      tzinfo
+      validate_email
+      validate_url
+      webfinger (~> 2.0)
     parallel (1.22.1)
     parser (3.1.3.0)
       ast (~> 2.4.1)
@@ -151,8 +162,16 @@ GEM
     pry-byebug (3.10.1)
       byebug (~> 11.0)
       pry (>= 0.13, < 0.15)
+    public_suffix (5.0.1)
     racc (1.6.2)
     rack (2.2.7)
+    rack-oauth2 (2.2.0)
+      activesupport
+      attr_required
+      faraday (~> 2.0)
+      faraday-follow_redirects
+      json-jwt (>= 1.11.0)
+      rack (>= 2.1.0)
     rack-protection (3.0.6)
       rack
     rack-test (2.0.2)
@@ -238,15 +257,26 @@ GEM
       simplecov_json_formatter (~> 0.1)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
-    snaky_hash (2.0.1)
-      hashie
-      version_gem (~> 1.1, >= 1.1.1)
+    swd (2.0.2)
+      activesupport (>= 3)
+      attr_required (>= 0.0.5)
+      faraday (~> 2.0)
+      faraday-follow_redirects
     thor (1.2.1)
     timeout (0.3.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     unicode-display_width (2.3.0)
-    version_gem (1.1.2)
+    validate_email (0.1.6)
+      activemodel (>= 3.0)
+      mail (>= 2.2.5)
+    validate_url (1.0.15)
+      activemodel (>= 3.0.0)
+      public_suffix
+    webfinger (2.1.2)
+      activesupport
+      faraday (~> 2.0)
+      faraday-follow_redirects
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)

--- a/README.md
+++ b/README.md
@@ -96,7 +96,13 @@ link_to 'Log in', rpi_auth_login_path, method: :post
 button_to 'Log in', rpi_auth_login_path
 ```
 
-There is also a helper for the logout route:
+There is a helper for the sign-up buttons, which pushes the user through the sign-up flow.
+
+```ruby
+button_to 'Sign up', rpi_auth_signup_path
+```
+
+And there is also a helper for the logout route:
 
 ```ruby
 link_to 'Log out', rpi_auth_logout_path

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ RpiAuth.configure do |config|
   config.auth_token_url = ENV.fetch('AUTH_TOKEN_URL', nil)
   config.auth_client_id = ENV.fetch('AUTH_CLIENT_ID', nil)
   config.auth_client_secret = ENV.fetch('AUTH_CLIENT_SECRET', nil)
-  config.brand = 'brand-name'
+  config.brand = 'raspberrypi-org'
   config.host_url = ENV.fetch('HOST_URL', nil)
   config.identity_url = ENV.fetch('IDENTITY_URL', nil)
   config.user_model = 'User'

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # RpiAuth
 
-A gem to handle authenticating via Hydra for Raspberry Pi Foundation Rails applications.
+A gem to handle OpenID Connect authentication via Hydra for Raspberry Pi Foundation Rails applications.
 
 ## Usage
 
@@ -11,7 +11,7 @@ The Engine includes the [Rails CSRF protection gem](https://github.com/cookpad/o
 Add this line to your application's Gemfile:
 
 ```ruby
-gem 'rpi_auth', git: 'https://github.com/RaspberryPiFoundation/rpi-auth.git', tag: 'v1.3.0'
+gem 'rpi_auth', git: 'https://github.com/RaspberryPiFoundation/rpi-auth.git', tag: 'v2.0.0'
 ```
 
 And then execute:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,7 +4,7 @@ Rails.application.routes.draw do
   # Dummy routes. These routes are never reached in the app, as Omniauth
   # intercepts it via Rack middleware before it reaches Rails, however adding
   # them allows us to use rpi_auth_login_path helpers etc.
-  post '/auth/rpi', as: :rpi_auth_login
+  post '/auth/rpi', as: :rpi_auth_login, params: { login_options: 'v1_signup' }
   post '/auth/rpi', as: :rpi_auth_signup, params: { login_options: 'force_signup,v1_signup' }
 
   namespace 'rpi_auth' do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,10 +1,11 @@
 # frozen_string_literal: true
 
 Rails.application.routes.draw do
-  # Dummy route. This route is never reached in the app, as Omniauth intercepts
-  # it via Rack middleware before it reaches Rails, however adding this route
-  # allows us to use rpi_auth_login_path helpers etc.
+  # Dummy routes. These routes are never reached in the app, as Omniauth
+  # intercepts it via Rack middleware before it reaches Rails, however adding
+  # them allows us to use rpi_auth_login_path helpers etc.
   post '/auth/rpi', as: :rpi_auth_login
+  post '/auth/rpi', as: :rpi_auth_signup, params: { login_options: 'force_signup,v1_signup' }
 
   namespace 'rpi_auth' do
     get '/auth/callback', to: 'auth#callback', as: 'callback'

--- a/gemfiles/rails_6.1.gemfile.lock
+++ b/gemfiles/rails_6.1.gemfile.lock
@@ -1,9 +1,9 @@
 PATH
   remote: ..
   specs:
-    rpi_auth (0.1.0)
+    rpi_auth (2.0.0)
       omniauth-rails_csrf_protection (~> 1.0.0)
-      omniauth-rpi (~> 1.1)
+      omniauth_openid_connect (~> 0.7.1)
       rails (>= 6.1.4)
 
 GEM
@@ -68,7 +68,10 @@ GEM
       minitest (>= 5.1)
       tzinfo (~> 2.0)
       zeitwerk (~> 2.3)
+    aes_key_wrap (1.1.0)
     ast (2.4.2)
+    attr_required (1.0.1)
+    bindata (2.4.15)
     builder (3.2.4)
     byebug (11.1.3)
     coderay (1.1.3)
@@ -77,9 +80,11 @@ GEM
     diff-lcs (1.5.0)
     docile (1.4.0)
     erubi (1.11.0)
-    faraday (2.7.1)
+    faraday (2.7.4)
       faraday-net_http (>= 2.0, < 3.1)
       ruby2_keywords (>= 0.0.4)
+    faraday-follow_redirects (0.3.0)
+      faraday (>= 1, < 3)
     faraday-net_http (3.0.2)
     ffi (1.15.5)
     globalid (1.0.0)
@@ -88,7 +93,12 @@ GEM
     i18n (1.12.0)
       concurrent-ruby (~> 1.0)
     json (2.6.2)
-    jwt (2.2.3)
+    json-jwt (1.16.3)
+      activesupport (>= 4.2)
+      aes_key_wrap
+      bindata
+      faraday (~> 2.0)
+      faraday-follow_redirects
     listen (3.7.1)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
@@ -101,33 +111,38 @@ GEM
     method_source (1.0.0)
     mini_mime (1.1.2)
     minitest (5.16.3)
-    multi_xml (0.6.0)
+    net-protocol (0.2.1)
+      timeout
+    net-smtp (0.3.3)
+      net-protocol
     nio4r (2.5.8)
     nokogiri (1.13.9-arm64-darwin)
       racc (~> 1.4)
     nokogiri (1.13.9-x86_64-linux)
       racc (~> 1.4)
-    oauth2 (2.0.9)
-      faraday (>= 0.17.3, < 3.0)
-      jwt (>= 1.0, < 3.0)
-      multi_xml (~> 0.5)
-      rack (>= 1.2, < 4)
-      snaky_hash (~> 2.0)
-      version_gem (~> 1.1)
-    omniauth (2.1.0)
+    omniauth (2.1.1)
       hashie (>= 3.4.6)
       rack (>= 2.2.3)
       rack-protection
-    omniauth-oauth2 (1.8.0)
-      oauth2 (>= 1.4, < 3)
-      omniauth (~> 2.0)
     omniauth-rails_csrf_protection (1.0.1)
       actionpack (>= 4.2)
       omniauth (~> 2.0)
-    omniauth-rpi (1.1.0)
-      jwt (~> 2.2.3)
-      omniauth (~> 2.0)
-      omniauth-oauth2 (~> 1.4)
+    omniauth_openid_connect (0.7.1)
+      omniauth (>= 1.9, < 3)
+      openid_connect (~> 2.2)
+    openid_connect (2.2.0)
+      activemodel
+      attr_required (>= 1.0.0)
+      faraday (~> 2.0)
+      faraday-follow_redirects
+      json-jwt (>= 1.16)
+      net-smtp
+      rack-oauth2 (~> 2.2)
+      swd (~> 2.0)
+      tzinfo
+      validate_email
+      validate_url
+      webfinger (~> 2.0)
     parallel (1.22.1)
     parser (3.1.3.0)
       ast (~> 2.4.1)
@@ -137,9 +152,17 @@ GEM
     pry-byebug (3.10.1)
       byebug (~> 11.0)
       pry (>= 0.13, < 0.15)
+    public_suffix (5.0.1)
     racc (1.6.0)
     rack (2.2.4)
-    rack-protection (3.0.4)
+    rack-oauth2 (2.2.0)
+      activesupport
+      attr_required
+      faraday (~> 2.0)
+      faraday-follow_redirects
+      json-jwt (>= 1.11.0)
+      rack (>= 2.1.0)
+    rack-protection (3.0.6)
       rack
     rack-test (2.0.2)
       rack (>= 1.3)
@@ -224,9 +247,6 @@ GEM
       simplecov_json_formatter (~> 0.1)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
-    snaky_hash (2.0.1)
-      hashie
-      version_gem (~> 1.1, >= 1.1.1)
     sprockets (4.1.1)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -234,11 +254,26 @@ GEM
       actionpack (>= 5.2)
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
+    swd (2.0.2)
+      activesupport (>= 3)
+      attr_required (>= 0.0.5)
+      faraday (~> 2.0)
+      faraday-follow_redirects
     thor (1.2.1)
+    timeout (0.3.2)
     tzinfo (2.0.5)
       concurrent-ruby (~> 1.0)
     unicode-display_width (2.3.0)
-    version_gem (1.1.1)
+    validate_email (0.1.6)
+      activemodel (>= 3.0)
+      mail (>= 2.2.5)
+    validate_url (1.0.15)
+      activemodel (>= 3.0.0)
+      public_suffix
+    webfinger (2.1.2)
+      activesupport
+      faraday (~> 2.0)
+      faraday-follow_redirects
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)

--- a/lib/rpi_auth/configuration.rb
+++ b/lib/rpi_auth/configuration.rb
@@ -10,8 +10,10 @@ module RpiAuth
                   :auth_token_url,
                   :brand,
                   :bypass_auth,
+                  :client_auth_method,
                   :host_url,
                   :identity_url,
+                  :response_type,
                   :scope,
                   :success_redirect,
                   :user_model
@@ -24,6 +26,22 @@ module RpiAuth
       return unless bypass_auth
 
       OmniAuth.config.enable_rpi_auth_bypass
+    end
+
+    def authorization_endpoint
+      @authorization_endpoint ||= URI.parse(auth_url).merge('/oauth2/auth')
+    end
+
+    def issuer
+      @issuer ||= token_endpoint.merge('/').to_s
+    end
+
+    def jwks_uri
+      @jwks_uri ||= token_endpoint.merge('/.well-known/jwks.json')
+    end
+
+    def token_endpoint
+      @token_endpoint ||= URI.parse(auth_token_url || auth_url).merge('/oauth2/token')
     end
   end
 end

--- a/lib/rpi_auth/configuration.rb
+++ b/lib/rpi_auth/configuration.rb
@@ -20,7 +20,6 @@ module RpiAuth
                   :user_model
 
     def initialize
-      @brand = 'raspberrypi-org'
       @bypass_auth = false
       @response_type = :code
       @client_auth_method = :basic

--- a/lib/rpi_auth/configuration.rb
+++ b/lib/rpi_auth/configuration.rb
@@ -4,10 +4,11 @@ module RpiAuth
   class Configuration
     using ::RpiAuthBypass
 
+    attr_writer :auth_token_url
+
     attr_accessor :auth_client_id,
                   :auth_client_secret,
                   :auth_url,
-                  :auth_token_url,
                   :brand,
                   :bypass_auth,
                   :client_auth_method,
@@ -20,6 +21,8 @@ module RpiAuth
 
     def initialize
       @bypass_auth = false
+      @response_type = :code
+      @client_auth_method = :basic
     end
 
     def enable_auth_bypass
@@ -28,7 +31,17 @@ module RpiAuth
       OmniAuth.config.enable_rpi_auth_bypass
     end
 
+    def disable_auth_bypass
+      OmniAuth.config.disable_rpi_auth_bypass
+    end
+
+    def auth_token_url
+      @auth_token_url || auth_url
+    end
+
     def authorization_endpoint
+      raise ArgumentError, 'No auth_url has been set yet' unless auth_url
+
       @authorization_endpoint ||= URI.parse(auth_url).merge('/oauth2/auth')
     end
 
@@ -41,7 +54,9 @@ module RpiAuth
     end
 
     def token_endpoint
-      @token_endpoint ||= URI.parse(auth_token_url || auth_url).merge('/oauth2/token')
+      raise ArgumentError, 'No auth_token_url or auth_url has been set yet' unless auth_token_url
+
+      @token_endpoint ||= URI.parse(auth_token_url).merge('/oauth2/token')
     end
   end
 end

--- a/lib/rpi_auth/configuration.rb
+++ b/lib/rpi_auth/configuration.rb
@@ -20,6 +20,7 @@ module RpiAuth
                   :user_model
 
     def initialize
+      @brand = 'raspberrypi-org'
       @bypass_auth = false
       @response_type = :code
       @client_auth_method = :basic

--- a/lib/rpi_auth/configuration.rb
+++ b/lib/rpi_auth/configuration.rb
@@ -4,7 +4,7 @@ module RpiAuth
   class Configuration
     using ::RpiAuthBypass
 
-    attr_writer :auth_token_url
+    attr_writer :auth_token_url, :issuer
 
     attr_accessor :auth_client_id,
                   :auth_client_secret,

--- a/lib/rpi_auth/engine.rb
+++ b/lib/rpi_auth/engine.rb
@@ -13,7 +13,7 @@ module RpiAuth
       OmniAuth.config.logger = Rails.logger
     end
 
-    initializer 'RpiAuth.add_middleware' do |app|
+    initializer 'RpiAuth.add_middleware' do |app| # rubocop:disable Metrics/BlockLength
       next unless RpiAuth.configuration
 
       app.middleware.use OmniAuth::Builder do
@@ -36,18 +36,14 @@ module RpiAuth
             jwks_uri: RpiAuth.configuration.jwks_uri
           },
           extra_authorize_params: { brand: RpiAuth.configuration.brand },
-          allow_authorize_params: [ :login_options ],
+          allow_authorize_params: [:login_options],
           origin_param: 'returnTo'
         )
 
         OmniAuth.config.on_failure = RpiAuth::AuthController.action(:failure)
+
+        RpiAuth.configuration.enable_auth_bypass if RpiAuth.configuration.bypass_auth
       end
-    end
-
-    config.after_initialize do
-      next unless RpiAuth.configuration
-
-      RpiAuth.configuration.enable_auth_bypass
     end
   end
 end

--- a/lib/rpi_auth/engine.rb
+++ b/lib/rpi_auth/engine.rb
@@ -14,10 +14,14 @@ module RpiAuth
     end
 
     initializer 'RpiAuth.bypass_auth' do
-      RpiAuth.configuration.enable_auth_bypass if RpiAuth.configuration
+      return unless RpiAuth.configuration
+
+      RpiAuth.configuration.enable_auth_bypass
     end
 
     initializer 'RpiAuth.add_middleware' do |app|
+      return unless RpiAuth.configuration
+
       app.middleware.use OmniAuth::Builder do
         provider(
           :openid_connect,

--- a/lib/rpi_auth/engine.rb
+++ b/lib/rpi_auth/engine.rb
@@ -36,6 +36,7 @@ module RpiAuth
             jwks_uri: RpiAuth.configuration.jwks_uri
           },
           extra_authorize_params: { brand: RpiAuth.configuration.brand },
+          allow_authorize_params: [ :login_options ],
           origin_param: 'returnTo'
         )
 

--- a/lib/rpi_auth/engine.rb
+++ b/lib/rpi_auth/engine.rb
@@ -14,13 +14,13 @@ module RpiAuth
     end
 
     initializer 'RpiAuth.bypass_auth' do
-      return unless RpiAuth.configuration
+      next unless RpiAuth.configuration
 
       RpiAuth.configuration.enable_auth_bypass
     end
 
     initializer 'RpiAuth.add_middleware' do |app|
-      return unless RpiAuth.configuration
+      next unless RpiAuth.configuration
 
       app.middleware.use OmniAuth::Builder do
         provider(

--- a/lib/rpi_auth/engine.rb
+++ b/lib/rpi_auth/engine.rb
@@ -9,6 +9,10 @@ module RpiAuth
 
     using ::RpiAuthBypass
 
+    initializer 'RpiAuth.set_logger' do
+      OmniAuth.config.logger = Rails.logger
+    end
+
     initializer 'RpiAuth.add_middleware' do |app|
       next unless RpiAuth.configuration
 
@@ -40,8 +44,9 @@ module RpiAuth
     end
 
     config.after_initialize do
-      OmniAuth.config.logger = Rails.logger
-      RpiAuth.configuration&.enable_auth_bypass
+      next unless RpiAuth.configuration
+
+      RpiAuth.configuration.enable_auth_bypass
     end
   end
 end

--- a/lib/rpi_auth/engine.rb
+++ b/lib/rpi_auth/engine.rb
@@ -14,7 +14,7 @@ module RpiAuth
     end
 
     initializer 'RpiAuth.bypass_auth' do
-      RpiAuth.configuration.enable_auth_bypass
+      RpiAuth.configuration.enable_auth_bypass if RpiAuth.configuration
     end
 
     initializer 'RpiAuth.add_middleware' do |app|

--- a/lib/rpi_auth/engine.rb
+++ b/lib/rpi_auth/engine.rb
@@ -9,16 +9,6 @@ module RpiAuth
 
     using ::RpiAuthBypass
 
-    initializer 'RpiAuth.set_logger' do
-      OmniAuth.config.logger = Rails.logger
-    end
-
-    initializer 'RpiAuth.bypass_auth' do
-      next unless RpiAuth.configuration
-
-      RpiAuth.configuration.enable_auth_bypass
-    end
-
     initializer 'RpiAuth.add_middleware' do |app|
       next unless RpiAuth.configuration
 
@@ -47,6 +37,11 @@ module RpiAuth
 
         OmniAuth.config.on_failure = RpiAuth::AuthController.action(:failure)
       end
+    end
+
+    config.after_initialize do
+      OmniAuth.config.logger = Rails.logger
+      RpiAuth.configuration&.enable_auth_bypass
     end
   end
 end

--- a/lib/rpi_auth/engine.rb
+++ b/lib/rpi_auth/engine.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
-require 'omniauth-rpi'
+require 'omniauth_openid_connect'
+require 'rpi_auth_bypass'
 
 module RpiAuth
   class Engine < ::Rails::Engine
@@ -19,17 +20,24 @@ module RpiAuth
     initializer 'RpiAuth.add_middleware' do |app|
       app.middleware.use OmniAuth::Builder do
         provider(
-          OmniAuth::Strategies::Rpi,
-          RpiAuth.configuration.auth_client_id,
-          RpiAuth.configuration.auth_client_secret,
+          :openid_connect,
+          name: :rpi,
+          issuer: RpiAuth.configuration.issuer,
           scope: RpiAuth.configuration.scope,
           callback_path: '/rpi_auth/auth/callback',
+          response_type: RpiAuth.configuration.response_type,
+          client_auth_method: RpiAuth.configuration.client_auth_method,
           client_options: {
-            site: RpiAuth.configuration.auth_url,
-            authorize_url: "#{RpiAuth.configuration.auth_url}/oauth2/auth",
-            token_url: "#{RpiAuth.configuration.auth_token_url || RpiAuth.configuration.auth_url}/oauth2/token"
+            identifier: RpiAuth.configuration.auth_client_id,
+            secret: RpiAuth.configuration.auth_client_secret,
+            scheme: RpiAuth.configuration.token_endpoint.scheme,
+            host: RpiAuth.configuration.token_endpoint.host,
+            port: RpiAuth.configuration.token_endpoint.port,
+            authorization_endpoint: RpiAuth.configuration.authorization_endpoint,
+            token_endpoint: RpiAuth.configuration.token_endpoint,
+            jwks_uri: RpiAuth.configuration.jwks_uri
           },
-          authorize_params: { brand: RpiAuth.configuration.brand },
+          extra_authorize_params: { brand: RpiAuth.configuration.brand },
           origin_param: 'returnTo'
         )
 

--- a/lib/rpi_auth_bypass.rb
+++ b/lib/rpi_auth_bypass.rb
@@ -12,26 +12,40 @@ module RpiAuthBypass
   DEFAULT_COUNTRY = 'United Kingdom'
   DEFAULT_COUNTRY_CODE = 'GB'
   DEFAULT_POSTCODE = 'SW1A 1AA'
+
   DEFAULT_INFO = {
     name: DEFAULT_NAME,
     nickname: DEFAULT_NICKNAME,
     email: DEFAULT_EMAIL,
+    email_verified: true,
     username: DEFAULT_USERNAME,
     image: DEFAULT_IMAGE
   }.freeze
+
   DEFAULT_EXTRA = {
     raw_info: {
-      roles: DEFAULT_ROLES,
-      name: DEFAULT_NAME,
-      nickname: DEFAULT_NICKNAME,
-      email: DEFAULT_EMAIL,
-      username: DEFAULT_USERNAME,
       country: DEFAULT_COUNTRY,
       country_code: DEFAULT_COUNTRY_CODE,
+      email: DEFAULT_EMAIL,
+      email_verified: true,
+      name: DEFAULT_NAME,
+      nickname: DEFAULT_NICKNAME,
+      picture: DEFAULT_IMAGE,
       postcode: DEFAULT_POSTCODE,
       profile: DEFAULT_PROFILE,
-      avatar: DEFAULT_IMAGE
+      roles: DEFAULT_ROLES,
+      sub: DEFAULT_UID,
+      user: DEFAULT_UID,
+      username: DEFAULT_USERNAME
     }
+  }.freeze
+
+  DEFAULT_CREDENTIALS = {
+    id_token: 'dummy-id-token',
+    token: 'dummy-access-token',
+    refresh_token: 'dummy-refresh-token',
+    expires_in: 3600,
+    scope: 'openid email profile force-consent roles offline'
   }.freeze
 
   refine OmniAuth::Configuration do
@@ -49,13 +63,16 @@ module RpiAuthBypass
       self.test_mode = self.rpi_auth_bypass = false
     end
 
-    def add_rpi_mock(uid: RpiAuthBypass::DEFAULT_UID, info: RpiAuthBypass::DEFAULT_INFO,
-                     extra: RpiAuthBypass::DEFAULT_EXTRA)
+    def add_rpi_mock(uid: RpiAuthBypass::DEFAULT_UID,
+                     info: RpiAuthBypass::DEFAULT_INFO,
+                     extra: RpiAuthBypass::DEFAULT_EXTRA,
+                     credentials: RpiAuthBypass::DEFAULT_CREDENTIALS)
       add_mock(:rpi, {
-                 provider: 'Rpi',
+                 provider: :rpi,
                  uid: uid,
                  info: info,
-                 extra: extra
+                 extra: extra,
+                 credentials: credentials
                })
     end
 

--- a/lib/rpi_auth_bypass.rb
+++ b/lib/rpi_auth_bypass.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+module RpiAuthBypass
+  DEFAULT_UID = 'b6301f34-b970-4d4f-8314-f877bad8b150'
+  DEFAULT_EMAIL = 'web@raspberrypi.org'
+  DEFAULT_USERNAME = 'webteam'
+  DEFAULT_NAME = 'Web Team'
+  DEFAULT_NICKNAME = 'Web'
+  DEFAULT_PROFILE = 'https://profile.raspberrypi.org/not/a/real/path'
+  DEFAULT_IMAGE = 'https://www.placecage.com/200/200'
+  DEFAULT_ROLES = 'user'
+  DEFAULT_COUNTRY = 'United Kingdom'
+  DEFAULT_COUNTRY_CODE = 'GB'
+  DEFAULT_POSTCODE = 'SW1A 1AA'
+  DEFAULT_INFO = {
+    name: DEFAULT_NAME,
+    nickname: DEFAULT_NICKNAME,
+    email: DEFAULT_EMAIL,
+    username: DEFAULT_USERNAME,
+    image: DEFAULT_IMAGE
+  }.freeze
+  DEFAULT_EXTRA = {
+    raw_info: {
+      roles: DEFAULT_ROLES,
+      name: DEFAULT_NAME,
+      nickname: DEFAULT_NICKNAME,
+      email: DEFAULT_EMAIL,
+      username: DEFAULT_USERNAME,
+      country: DEFAULT_COUNTRY,
+      country_code: DEFAULT_COUNTRY_CODE,
+      postcode: DEFAULT_POSTCODE,
+      profile: DEFAULT_PROFILE,
+      avatar: DEFAULT_IMAGE
+    }
+  }.freeze
+
+  refine OmniAuth::Configuration do
+    def enable_rpi_auth_bypass
+      logger.info 'Enabling RpiAuthBypass'
+      add_rpi_mock unless @mock_auth[:rpi]
+
+      self.test_mode = self.rpi_auth_bypass = true
+    end
+
+    def disable_rpi_auth_bypass
+      logger.debug 'Disabing RpiAuthBypass'
+      @mock_auth.delete(:rpi)
+
+      self.test_mode = self.rpi_auth_bypass = false
+    end
+
+    def add_rpi_mock(uid: RpiAuthBypass::DEFAULT_UID, info: RpiAuthBypass::DEFAULT_INFO,
+                     extra: RpiAuthBypass::DEFAULT_EXTRA)
+      add_mock(:rpi, {
+                 provider: 'Rpi',
+                 uid: uid,
+                 info: info,
+                 extra: extra
+               })
+    end
+
+    attr_writer :rpi_auth_bypass
+  end
+end

--- a/rpi_auth.gemspec
+++ b/rpi_auth.gemspec
@@ -27,6 +27,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency 'listen'
   spec.add_development_dependency 'pry-byebug'
+  spec.add_development_dependency 'puma'
   spec.add_development_dependency 'rspec_junit_formatter'
   spec.add_development_dependency 'rspec-rails'
   spec.add_development_dependency 'rubocop'

--- a/rpi_auth.gemspec
+++ b/rpi_auth.gemspec
@@ -21,8 +21,8 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 2.7.7'
 
-  spec.add_dependency 'omniauth-rails_csrf_protection', '~> 1.0.0'
   spec.add_dependency 'omniauth_openid_connect', '~> 0.7.1'
+  spec.add_dependency 'omniauth-rails_csrf_protection', '~> 1.0.0'
   spec.add_dependency 'rails', '>= 6.1.4'
 
   spec.add_development_dependency 'listen'

--- a/rpi_auth.gemspec
+++ b/rpi_auth.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 2.7.7'
 
   spec.add_dependency 'omniauth-rails_csrf_protection', '~> 1.0.0'
-  spec.add_dependency 'omniauth-rpi', '~> 1.4.0'
+  spec.add_dependency 'omniauth_openid_connect', '~> 0.7.1'
   spec.add_dependency 'rails', '>= 6.1.4'
 
   spec.add_development_dependency 'listen'

--- a/spec/dummy/app/controllers/home_controller.rb
+++ b/spec/dummy/app/controllers/home_controller.rb
@@ -1,5 +1,4 @@
 class HomeController < ApplicationController
   def show
-    current_user
   end
 end

--- a/spec/dummy/app/views/home/show.html.erb
+++ b/spec/dummy/app/views/home/show.html.erb
@@ -7,6 +7,8 @@
   <% else %>
     <%= button_to 'Log in', rpi_auth_login_path, method: :post %>
     <br />
-    <%= link_to 'Log in GET', rpi_auth_login_path %>
+    <%= link_to 'Log in GET', rpi_auth_login_path %> (should 404)
+    <br />
+    <%= button_to 'Sign up', rpi_auth_signup_path, method: :post %>
   <% end %>
 </p>

--- a/spec/dummy/app/views/home/show.html.erb
+++ b/spec/dummy/app/views/home/show.html.erb
@@ -5,8 +5,8 @@
     Logged in as <%= current_user.user_id %>
     <%= link_to 'Log out', rpi_auth_logout_path, class: 'button' %>
   <% else %>
-    <%= link_to 'Log in', rpi_auth_login_path, method: :post %>
-
+    <%= button_to 'Log in', rpi_auth_login_path, method: :post %>
+    <br />
     <%= link_to 'Log in GET', rpi_auth_login_path %>
   <% end %>
 </p>

--- a/spec/dummy/app/views/layouts/application.html.erb
+++ b/spec/dummy/app/views/layouts/application.html.erb
@@ -5,8 +5,6 @@
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
-
-    <%= stylesheet_link_tag "application" %>
   </head>
 
   <body>

--- a/spec/dummy/config/environments/development.rb
+++ b/spec/dummy/config/environments/development.rb
@@ -43,13 +43,13 @@ Rails.application.configure do
   config.active_support.disallowed_deprecation_warnings = []
 
   # Raise an error on page load if there are pending migrations.
-  config.active_record.migration_error = :page_load
+  # config.active_record.migration_error = :page_load
 
   # Highlight code that triggered database queries in logs.
-  config.active_record.verbose_query_logs = true
+  # config.active_record.verbose_query_logs = true
 
   # Suppress logger output for asset requests.
-  config.assets.quiet = true
+  # config.assets.quiet = true
 
   # Raises error for missing translations.
   # config.i18n.raise_on_missing_translations = true

--- a/spec/dummy/config/initializers/rpi_auth.rb
+++ b/spec/dummy/config/initializers/rpi_auth.rb
@@ -8,6 +8,8 @@ RpiAuth.configure do |config|
   config.identity_url = 'http://localhost:3002'
   config.user_model = 'User'
 
+  config.bypass_auth = false
+
   # Profile is running in docker, so we need to set this manually.  This
   # shouldn't be needed elsewhere, unless you're getting errors saying:
   #   Invalid ID token: Issuer does not match

--- a/spec/dummy/config/initializers/rpi_auth.rb
+++ b/spec/dummy/config/initializers/rpi_auth.rb
@@ -2,8 +2,14 @@ RpiAuth.configure do |config|
   config.auth_url = 'http://localhost:9001'
   config.auth_client_id = 'gem-dev'
   config.auth_client_secret = 'secret'
+  config.scope = %w[email force-consent openid profile roles allow-u13-login require-parental-consent]
   config.brand = 'codeclub'
-  config.host_url = 'http://localhost:3000'
+  config.host_url = 'http://localhost:3009'
   config.identity_url = 'http://localhost:3002'
   config.user_model = 'User'
+
+  # Profile is running in docker, so we need to set this manually.  This
+  # shouldn't be needed elsewhere, unless you're getting errors saying:
+  #   Invalid ID token: Issuer does not match
+  config.issuer = "http://host.docker.internal:9001/"
 end

--- a/spec/dummy/config/initializers/rpi_auth.rb
+++ b/spec/dummy/config/initializers/rpi_auth.rb
@@ -1,25 +1,9 @@
-if Rails.env.development?
-  RpiAuth.configure do |config|
-    config.auth_url = 'http://localhost:9001'
-    config.auth_client_id = 'gem-dev'
-    config.auth_client_secret = 'secret'
-    config.brand = 'codeclub'
-    config.host_url = 'http://localhost:3000'
-    config.identity_url = 'http://localhost:3002'
-    config.user_model = 'User'
-    config.bypass_auth = false
-  end
-end
-
-if Rails.env.test?
-  RpiAuth.configure do |config|
-    config.auth_url = 'https://auth.example.com'
-    config.auth_client_id = 'clientid'
-    config.auth_client_secret = 'clientsecret'
-    config.brand = 'codeclub'
-    config.host_url = 'https://example.com'
-    config.identity_url = 'https://my.example.com'
-    config.user_model = 'User'
-    config.bypass_auth = true
-  end
+RpiAuth.configure do |config|
+  config.auth_url = 'http://localhost:9001'
+  config.auth_client_id = 'gem-dev'
+  config.auth_client_secret = 'secret'
+  config.brand = 'codeclub'
+  config.host_url = 'http://localhost:3000'
+  config.identity_url = 'http://localhost:3002'
+  config.user_model = 'User'
 end

--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -2,5 +2,6 @@ Rails.application.routes.draw do
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
   root to: 'home#show'
 
-  get '/*slug', to: 'home#show'
+  # Make sure we don't match auth routes
+  get '/*slug', to: 'home#show', constraints: { slug: /(?!(rpi_)?auth\/).*/ }
 end

--- a/spec/dummy/spec/requests/auth_request_spec.rb
+++ b/spec/dummy/spec/requests/auth_request_spec.rb
@@ -26,7 +26,8 @@ RSpec.describe 'Authentication' do
     RpiAuth.configuration.bypass_auth = bypass_auth
     # This would normally be in the initializer, but because we're toggling the
     # option on or off, we need to explicitly call it here.
-    RpiAuth.configuration.enable_auth_bypass if bypass_auth
+    RpiAuth.configuration.enable_auth_bypass
+    OmniAuth.config.test_mode = true
   end
 
   describe 'GET /rpi_auth/logout' do
@@ -49,7 +50,7 @@ RSpec.describe 'Authentication' do
         post '/auth/rpi'
         follow_redirect!
 
-        expect(session['current_user']['user_id']).to be 'b6301f34-b970-4d4f-8314-f877bad8b150'
+        expect(session['current_user']['user_id']).to eq RpiAuthBypass::DEFAULT_UID
         previous_id = session.id
 
         get '/rpi_auth/logout'
@@ -105,7 +106,7 @@ RSpec.describe 'Authentication' do
         expect(response).to redirect_to('/')
         follow_redirect!
 
-        expect(session['current_user']['user_id']).to eq 'b6301f34-b970-4d4f-8314-f877bad8b150'
+        expect(session['current_user']['user_id']).to eq RpiAuthBypass::DEFAULT_UID
       end
     end
 

--- a/spec/dummy/spec/views/home_show_spec.rb
+++ b/spec/dummy/spec/views/home_show_spec.rb
@@ -17,7 +17,12 @@ RSpec.describe 'home/show' do
 
     it 'shows the correct log in link' do
       render
-      expect(html.search('a[href="/auth/rpi"]')).not_to be_empty
+      expect(html.search('form[action="/auth/rpi?login_options=v1_signup"]')).not_to be_empty
+    end
+
+    it 'shows the sign up link' do
+      render
+      expect(html.search('form[action="/auth/rpi?login_options=force_signup%2Cv1_signup"]')).not_to be_empty
     end
   end
 

--- a/spec/rpi_auth/configuration_spec.rb
+++ b/spec/rpi_auth/configuration_spec.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+RSpec.describe RpiAuth::Configuration do
+  subject(:configuration) { described_class.new }
+
+  let(:auth_url) { 'https://auth.com:123/' }
+  let(:auth_token_url) { 'https://internal.auth.com:456' }
+
+  it 'sets a default value for client_auth_method' do
+    expect(configuration.client_auth_method).to eq :basic
+  end
+
+  it 'sets a default value for response_type' do
+    expect(configuration.response_type).to eq :code
+  end
+
+  describe '#authorization_endpoint' do
+    it 'raises an exception if auth_url is not set' do
+      expect { configuration.authorization_endpoint }.to raise_exception(ArgumentError)
+    end
+
+    context 'when auth_url is set' do
+      let(:expected_url) { auth_url }
+
+      before { configuration.auth_url = auth_url }
+
+      it 'sets the authorization_endpoint correctly' do
+        expect(configuration.authorization_endpoint).to eq URI.parse(auth_url).merge('/oauth2/auth')
+      end
+    end
+  end
+
+  shared_examples 'sets up the token url defaults' do
+    it 'sets the issuer' do
+      expect(configuration.issuer).to eq URI.parse(expected_url).merge('/').to_s
+    end
+
+    it 'sets the token_endpoint' do
+      expect(configuration.token_endpoint).to eq URI.parse(expected_url).merge('/oauth2/token')
+    end
+
+    it 'sets the jwks uri' do
+      expect(configuration.jwks_uri).to eq URI.parse(expected_url).merge('/.well-known/jwks.json')
+    end
+  end
+
+  describe '#token_endpoint' do
+    it 'raises an exception if auth_url is not set' do
+      expect { configuration.token_endpoint }.to raise_exception(ArgumentError)
+    end
+
+    context 'when auth_url is set' do
+      let(:expected_url) { auth_url }
+      before { configuration.auth_url = auth_url }
+
+      it_behaves_like 'sets up the token url defaults'
+
+      context 'when auth_token_url is set' do
+        let(:expected_url) { auth_token_url }
+
+        before { configuration.auth_token_url = auth_token_url }
+
+        it_behaves_like 'sets up the token url defaults'
+      end
+    end
+
+    context 'when auth_token_url is set' do
+      let(:expected_url) { auth_token_url }
+
+      before { configuration.auth_token_url = auth_token_url }
+
+      it_behaves_like 'sets up the token url defaults'
+    end
+  end
+end

--- a/spec/rpi_auth/configuration_spec.rb
+++ b/spec/rpi_auth/configuration_spec.rb
@@ -14,6 +14,43 @@ RSpec.describe RpiAuth::Configuration do
     expect(configuration.response_type).to eq :code
   end
 
+  it 'sets bypass_auth to false by default' do
+    expect(configuration.bypass_auth).to be_falsey
+  end
+
+  describe '#enable_auth_bypass' do
+    context 'when bypass_auth is true' do
+      before do
+        configuration.bypass_auth = true
+      end
+
+      it 'enables OmniAuth test mode' do
+        expect { configuration.enable_auth_bypass }.to change { OmniAuth.config.test_mode }.from(false).to(true)
+      end
+    end
+
+    context 'when bypass_auth is false' do
+      before do
+        configuration.bypass_auth = false
+      end
+
+      it 'does not enable OmniAuth test mode' do
+        expect { configuration.enable_auth_bypass }.not_to change { OmniAuth.config.test_mode }.from(false)
+      end
+    end
+  end
+
+  describe 'disable_auth_bypass' do
+    before do
+      configuration.bypass_auth = true
+      configuration.enable_auth_bypass
+    end
+
+    it 'disables OmniAuth test mode' do
+      expect { configuration.disable_auth_bypass }.to change { OmniAuth.config.test_mode }.from(true).to(false)
+    end
+  end
+
   describe '#authorization_endpoint' do
     it 'raises an exception if auth_url is not set' do
       expect { configuration.authorization_endpoint }.to raise_exception(ArgumentError)

--- a/spec/rpi_auth/configuration_spec.rb
+++ b/spec/rpi_auth/configuration_spec.rb
@@ -6,6 +6,10 @@ RSpec.describe RpiAuth::Configuration do
   let(:auth_url) { 'https://auth.com:123/' }
   let(:auth_token_url) { 'https://internal.auth.com:456' }
 
+  it 'sets a default value for brand' do
+    expect(configuration.brand).to eq 'raspberrypi-org'
+  end
+
   it 'sets a default value for client_auth_method' do
     expect(configuration.client_auth_method).to eq :basic
   end

--- a/spec/rpi_auth/configuration_spec.rb
+++ b/spec/rpi_auth/configuration_spec.rb
@@ -51,6 +51,7 @@ RSpec.describe RpiAuth::Configuration do
 
     context 'when auth_url is set' do
       let(:expected_url) { auth_url }
+
       before { configuration.auth_url = auth_url }
 
       it_behaves_like 'sets up the token url defaults'

--- a/spec/rpi_auth/configuration_spec.rb
+++ b/spec/rpi_auth/configuration_spec.rb
@@ -6,10 +6,6 @@ RSpec.describe RpiAuth::Configuration do
   let(:auth_url) { 'https://auth.com:123/' }
   let(:auth_token_url) { 'https://internal.auth.com:456' }
 
-  it 'sets a default value for brand' do
-    expect(configuration.brand).to eq 'raspberrypi-org'
-  end
-
   it 'sets a default value for client_auth_method' do
     expect(configuration.client_auth_method).to eq :basic
   end

--- a/spec/rpi_auth_bypass_spec.rb
+++ b/spec/rpi_auth_bypass_spec.rb
@@ -28,156 +28,123 @@ RSpec.describe RpiAuthBypass do
     end
   end
 
+  shared_examples 'a mocked auth object' do
+    let(:raw_info) { extra[:raw_info] }
+
+    it 'has the uid' do
+      expect(mock_auth.uid).to eq(uid)
+    end
+
+    it 'has the email from info' do
+      expect(mock_auth.info.email).to eq(info[:email])
+    end
+
+    it 'has the username from info' do
+      expect(mock_auth.info.username).to eq(info[:username])
+    end
+
+    it 'has the name from info' do
+      expect(mock_auth.info.name).to eq info[:name]
+    end
+
+    it 'has the nickname from info' do
+      expect(mock_auth.info.nickname).to eq info[:nickname]
+    end
+
+    it 'has the image from info' do
+      expect(mock_auth.info.image).to eq info[:image]
+    end
+
+    it 'has the email from raw_info' do
+      expect(mock_auth.extra.raw_info.email).to eq raw_info[:email]
+    end
+
+    it 'has the username from raw_info' do
+      expect(mock_auth.extra.raw_info.username).to eq raw_info[:username]
+    end
+
+    it 'has the name from raw_info' do
+      expect(mock_auth.extra.raw_info.name).to eq raw_info[:name]
+    end
+
+    it 'has the nickname from raw_info' do
+      expect(mock_auth.extra.raw_info.nickname).to eq raw_info[:nickname]
+    end
+
+    it 'has the roles from raw_info' do
+      expect(mock_auth.extra.raw_info.roles).to eq raw_info[:roles]
+    end
+
+    it 'has the sub from raw_info' do
+      expect(mock_auth.extra.raw_info.sub).to eq raw_info[:sub]
+    end
+
+    it 'has the user from raw_info' do
+      expect(mock_auth.extra.raw_info.user).to eq raw_info[:user]
+    end
+
+    it 'has the profile from raw_info' do
+      expect(mock_auth.extra.raw_info.profile).to eq raw_info[:profile]
+    end
+
+    it 'has the country from raw_info' do
+      expect(mock_auth.extra.raw_info.country).to eq raw_info[:country]
+    end
+
+    it 'has the country_code from raw_info' do
+      expect(mock_auth.extra.raw_info.country_code).to eq raw_info[:country_code]
+    end
+
+    it 'has the postcode from raw_info' do
+      expect(mock_auth.extra.raw_info.postcode).to eq raw_info[:postcode]
+    end
+  end
+
   describe 'OmniAuth::Configuration#add_rpi_mock' do
     subject(:mock_auth) { OmniAuth.config.mock_auth[:rpi] }
 
     let(:args) { {} }
+    let(:uid) { RpiAuthBypass::DEFAULT_UID }
+    let(:info) { RpiAuthBypass::DEFAULT_INFO }
+    let(:extra) { RpiAuthBypass::DEFAULT_EXTRA }
 
     before do
       OmniAuth.config.add_rpi_mock(**args)
     end
 
-    it 'has the default uid' do
-      expect(mock_auth.uid).to eq(RpiAuthBypass::DEFAULT_UID)
-    end
+    it_behaves_like 'a mocked auth object'
 
-    it 'has the default email' do
-      expect(mock_auth.info.email).to eq(RpiAuthBypass::DEFAULT_EMAIL)
-    end
-
-    it 'has the default username' do
-      expect(mock_auth.info.username).to eq(RpiAuthBypass::DEFAULT_USERNAME)
-    end
-
-    it 'has the default name' do
-      expect(mock_auth.info.name).to eq(RpiAuthBypass::DEFAULT_NAME)
-    end
-
-    it 'has the default nickname' do
-      expect(mock_auth.info.nickname).to eq(RpiAuthBypass::DEFAULT_NICKNAME)
-    end
-
-    it 'has the default image' do
-      expect(mock_auth.info.image).to eq(RpiAuthBypass::DEFAULT_IMAGE)
-    end
-
-    it 'has the default roles' do
-      expect(mock_auth.extra.raw_info.roles).to eq(RpiAuthBypass::DEFAULT_ROLES)
-    end
-
-    it 'has the default avatar' do
-      expect(mock_auth.extra.raw_info.avatar).to eq(RpiAuthBypass::DEFAULT_IMAGE)
-    end
-
-    it 'has the default profile' do
-      expect(mock_auth.extra.raw_info.profile).to eq(RpiAuthBypass::DEFAULT_PROFILE)
-    end
-
-    it 'has the default country' do
-      expect(mock_auth.extra.raw_info.country).to eq(RpiAuthBypass::DEFAULT_COUNTRY)
-    end
-
-    it 'has the default country code' do
-      expect(mock_auth.extra.raw_info.country_code).to eq(RpiAuthBypass::DEFAULT_COUNTRY_CODE)
-    end
-
-    it 'has the default postcode' do
-      expect(mock_auth.extra.raw_info.postcode).to eq(RpiAuthBypass::DEFAULT_POSTCODE)
-    end
-
-    context 'with info and extra specified' do # rubocop:disable RSpec/MultipleMemoizedHelpers
+    context 'with info and extra specified' do
       let(:uid) { '1d27cca2-fef3-4f79-bc64-b76e93db84a2' }
-      let(:name) { 'Robert Flemming' }
-      let(:nickname) { 'Bob' }
-      let(:email) { 'bob.flemming@example.com' }
-      let(:username) { 'bob.flemming' }
-      let(:roles) { 'gardener' }
-      let(:image) { 'https://my.avatar.com/image/1' }
-      let(:profile) { 'https://my.user.com/profile/1' }
-      let(:country) { 'United States' }
-      let(:country_code) { 'US' }
-      let(:postcode) { '123456' }
 
-      let(:info) { { name: name, email: email, username: username, nickname: nickname, image: image } }
+      let(:info) do
+        {
+          name: 'Robert Flemming',
+          email: 'bob.flemming@example.com',
+          username: 'bob.flemming',
+          nickname: 'Bob',
+          image: 'https://my.avatar.com/image/1'
+        }
+      end
+
       let(:extra) do
         { raw_info: {
-          name: name,
-          email: email,
-          username: username,
-          nickname: nickname,
-          roles: roles,
-          avatar: image,
-          profile: profile,
-          country: country,
-          country_code: country_code,
-          postcode: postcode
+          country: 'US',
+          country_code: 'United States',
+          email: info[:email],
+          name: info[:name],
+          nickname: info[:nickname],
+          postcode: '90210',
+          profile: 'https://my.user.com/profile/1',
+          roles: 'gardener',
+          sub: uid,
+          user: uid,
+          username: info[:username]
         } }
       end
       let(:args) { { uid: uid, info: info, extra: extra } }
 
-      it 'has the uid' do
-        expect(mock_auth.uid).to eq(uid)
-      end
-
-      it 'has the email from info' do
-        expect(mock_auth.info.email).to eq(email)
-      end
-
-      it 'has the username from info' do
-        expect(mock_auth.info.username).to eq(username)
-      end
-
-      it 'has the name from info' do
-        expect(mock_auth.info.name).to eq(name)
-      end
-
-      it 'has the nickname from info' do
-        expect(mock_auth.info.nickname).to eq(nickname)
-      end
-
-      it 'has the image from info' do
-        expect(mock_auth.info.image).to eq(image)
-      end
-
-      it 'has the email from extra' do
-        expect(mock_auth.extra.raw_info.email).to eq(email)
-      end
-
-      it 'has the username from extra' do
-        expect(mock_auth.extra.raw_info.username).to eq(username)
-      end
-
-      it 'has the name from extra' do
-        expect(mock_auth.extra.raw_info.name).to eq(name)
-      end
-
-      it 'has the nickname from extra' do
-        expect(mock_auth.extra.raw_info.nickname).to eq(nickname)
-      end
-
-      it 'has the roles from extra' do
-        expect(mock_auth.extra.raw_info.roles).to eq(roles)
-      end
-
-      it 'has the avatar from extra' do
-        expect(mock_auth.extra.raw_info.avatar).to eq(image)
-      end
-
-      it 'has the profile from extra' do
-        expect(mock_auth.extra.raw_info.profile).to eq(profile)
-      end
-
-      it 'has the country from extra' do
-        expect(mock_auth.extra.raw_info.country).to eq(country)
-      end
-
-      it 'has the country_code from extra' do
-        expect(mock_auth.extra.raw_info.country_code).to eq(country_code)
-      end
-
-      it 'has the postcode from extra' do
-        expect(mock_auth.extra.raw_info.postcode).to eq(postcode)
-      end
+      it_behaves_like 'a mocked auth object'
     end
   end
 end

--- a/spec/rpi_auth_bypass_spec.rb
+++ b/spec/rpi_auth_bypass_spec.rb
@@ -9,7 +9,6 @@ RSpec.describe RpiAuthBypass do
     # Alter logger to hide log messages.
     level = OmniAuth.config.logger.level
     OmniAuth.config.logger.level = Logger::WARN
-    OmniAuth.config.test_mode = false
 
     example.run
 
@@ -21,7 +20,6 @@ RSpec.describe RpiAuthBypass do
     subject(:call) { OmniAuth.config.enable_rpi_auth_bypass }
 
     it 'sets test_mode to true' do
-      pp OmniAuth.config.test_mode
       expect { call }.to change { OmniAuth.config.test_mode }.from(false).to(true)
     end
 

--- a/spec/rpi_auth_bypass_spec.rb
+++ b/spec/rpi_auth_bypass_spec.rb
@@ -87,7 +87,7 @@ RSpec.describe RpiAuthBypass do
       expect(mock_auth.extra.raw_info.postcode).to eq(RpiAuthBypass::DEFAULT_POSTCODE)
     end
 
-    context 'with info and extra specified' do
+    context 'with info and extra specified' do # rubocop:disable RSpec/MultipleMemoizedHelpers
       let(:uid) { '1d27cca2-fef3-4f79-bc64-b76e93db84a2' }
       let(:name) { 'Robert Flemming' }
       let(:nickname) { 'Bob' }
@@ -101,82 +101,84 @@ RSpec.describe RpiAuthBypass do
       let(:postcode) { '123456' }
 
       let(:info) { { name: name, email: email, username: username, nickname: nickname, image: image } }
-      let(:extra) { { raw_info: {
-        name: name,
-        email: email,
-        username: username,
-        nickname: nickname,
-        roles: roles,
-        avatar: image,
-        profile: profile,
-        country: country,
-        country_code: country_code,
-        postcode: postcode
-      } } }
+      let(:extra) do
+        { raw_info: {
+          name: name,
+          email: email,
+          username: username,
+          nickname: nickname,
+          roles: roles,
+          avatar: image,
+          profile: profile,
+          country: country,
+          country_code: country_code,
+          postcode: postcode
+        } }
+      end
       let(:args) { { uid: uid, info: info, extra: extra } }
 
       it 'has the uid' do
-        expect(subject.uid).to eq(uid)
+        expect(mock_auth.uid).to eq(uid)
       end
 
       it 'has the email from info' do
-        expect(subject.info.email).to eq(email)
+        expect(mock_auth.info.email).to eq(email)
       end
 
       it 'has the username from info' do
-        expect(subject.info.username).to eq(username)
+        expect(mock_auth.info.username).to eq(username)
       end
 
       it 'has the name from info' do
-        expect(subject.info.name).to eq(name)
+        expect(mock_auth.info.name).to eq(name)
       end
 
       it 'has the nickname from info' do
-        expect(subject.info.nickname).to eq(nickname)
+        expect(mock_auth.info.nickname).to eq(nickname)
       end
 
       it 'has the image from info' do
-        expect(subject.info.image).to eq(image)
+        expect(mock_auth.info.image).to eq(image)
       end
 
       it 'has the email from extra' do
-        expect(subject.extra.raw_info.email).to eq(email)
+        expect(mock_auth.extra.raw_info.email).to eq(email)
       end
 
       it 'has the username from extra' do
-        expect(subject.extra.raw_info.username).to eq(username)
+        expect(mock_auth.extra.raw_info.username).to eq(username)
       end
 
       it 'has the name from extra' do
-        expect(subject.extra.raw_info.name).to eq(name)
+        expect(mock_auth.extra.raw_info.name).to eq(name)
       end
 
       it 'has the nickname from extra' do
-        expect(subject.extra.raw_info.nickname).to eq(nickname)
+        expect(mock_auth.extra.raw_info.nickname).to eq(nickname)
       end
 
       it 'has the roles from extra' do
-        expect(subject.extra.raw_info.roles).to eq(roles)
+        expect(mock_auth.extra.raw_info.roles).to eq(roles)
       end
 
       it 'has the avatar from extra' do
-        expect(subject.extra.raw_info.avatar).to eq(image)
+        expect(mock_auth.extra.raw_info.avatar).to eq(image)
       end
 
       it 'has the profile from extra' do
-        expect(subject.extra.raw_info.profile).to eq(profile)
+        expect(mock_auth.extra.raw_info.profile).to eq(profile)
       end
 
       it 'has the country from extra' do
-        expect(subject.extra.raw_info.country).to eq(country)
+        expect(mock_auth.extra.raw_info.country).to eq(country)
       end
 
       it 'has the country_code from extra' do
-        expect(subject.extra.raw_info.country_code).to eq(country_code)
+        expect(mock_auth.extra.raw_info.country_code).to eq(country_code)
       end
 
       it 'has the postcode from extra' do
-        expect(subject.extra.raw_info.postcode).to eq(postcode)
+        expect(mock_auth.extra.raw_info.postcode).to eq(postcode)
       end
     end
   end

--- a/spec/rpi_auth_bypass_spec.rb
+++ b/spec/rpi_auth_bypass_spec.rb
@@ -1,0 +1,183 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe RpiAuthBypass do
+  using described_class
+
+  around do |example|
+    # Alter logger to hide log messages.
+    level = OmniAuth.config.logger.level
+    OmniAuth.config.logger.level = Logger::WARN
+    OmniAuth.config.test_mode = false
+
+    example.run
+
+    OmniAuth.config.disable_rpi_auth_bypass
+    OmniAuth.config.logger.level = level
+  end
+
+  describe 'OmniAuth::Configuration#enable_rpi_auth_bypass' do
+    subject(:call) { OmniAuth.config.enable_rpi_auth_bypass }
+
+    it 'sets test_mode to true' do
+      pp OmniAuth.config.test_mode
+      expect { call }.to change { OmniAuth.config.test_mode }.from(false).to(true)
+    end
+
+    it 'adds the rpi mock' do
+      expect { call }.to change { OmniAuth.config.mock_auth[:rpi] }.from(nil)
+    end
+  end
+
+  describe 'OmniAuth::Configuration#add_rpi_mock' do
+    subject(:mock_auth) { OmniAuth.config.mock_auth[:rpi] }
+
+    let(:args) { {} }
+
+    before do
+      OmniAuth.config.add_rpi_mock(**args)
+    end
+
+    it 'has the default uid' do
+      expect(mock_auth.uid).to eq(RpiAuthBypass::DEFAULT_UID)
+    end
+
+    it 'has the default email' do
+      expect(mock_auth.info.email).to eq(RpiAuthBypass::DEFAULT_EMAIL)
+    end
+
+    it 'has the default username' do
+      expect(mock_auth.info.username).to eq(RpiAuthBypass::DEFAULT_USERNAME)
+    end
+
+    it 'has the default name' do
+      expect(mock_auth.info.name).to eq(RpiAuthBypass::DEFAULT_NAME)
+    end
+
+    it 'has the default nickname' do
+      expect(mock_auth.info.nickname).to eq(RpiAuthBypass::DEFAULT_NICKNAME)
+    end
+
+    it 'has the default image' do
+      expect(mock_auth.info.image).to eq(RpiAuthBypass::DEFAULT_IMAGE)
+    end
+
+    it 'has the default roles' do
+      expect(mock_auth.extra.raw_info.roles).to eq(RpiAuthBypass::DEFAULT_ROLES)
+    end
+
+    it 'has the default avatar' do
+      expect(mock_auth.extra.raw_info.avatar).to eq(RpiAuthBypass::DEFAULT_IMAGE)
+    end
+
+    it 'has the default profile' do
+      expect(mock_auth.extra.raw_info.profile).to eq(RpiAuthBypass::DEFAULT_PROFILE)
+    end
+
+    it 'has the default country' do
+      expect(mock_auth.extra.raw_info.country).to eq(RpiAuthBypass::DEFAULT_COUNTRY)
+    end
+
+    it 'has the default country code' do
+      expect(mock_auth.extra.raw_info.country_code).to eq(RpiAuthBypass::DEFAULT_COUNTRY_CODE)
+    end
+
+    it 'has the default postcode' do
+      expect(mock_auth.extra.raw_info.postcode).to eq(RpiAuthBypass::DEFAULT_POSTCODE)
+    end
+
+    context 'with info and extra specified' do
+      let(:uid) { '1d27cca2-fef3-4f79-bc64-b76e93db84a2' }
+      let(:name) { 'Robert Flemming' }
+      let(:nickname) { 'Bob' }
+      let(:email) { 'bob.flemming@example.com' }
+      let(:username) { 'bob.flemming' }
+      let(:roles) { 'gardener' }
+      let(:image) { 'https://my.avatar.com/image/1' }
+      let(:profile) { 'https://my.user.com/profile/1' }
+      let(:country) { 'United States' }
+      let(:country_code) { 'US' }
+      let(:postcode) { '123456' }
+
+      let(:info) { { name: name, email: email, username: username, nickname: nickname, image: image } }
+      let(:extra) { { raw_info: {
+        name: name,
+        email: email,
+        username: username,
+        nickname: nickname,
+        roles: roles,
+        avatar: image,
+        profile: profile,
+        country: country,
+        country_code: country_code,
+        postcode: postcode
+      } } }
+      let(:args) { { uid: uid, info: info, extra: extra } }
+
+      it 'has the uid' do
+        expect(subject.uid).to eq(uid)
+      end
+
+      it 'has the email from info' do
+        expect(subject.info.email).to eq(email)
+      end
+
+      it 'has the username from info' do
+        expect(subject.info.username).to eq(username)
+      end
+
+      it 'has the name from info' do
+        expect(subject.info.name).to eq(name)
+      end
+
+      it 'has the nickname from info' do
+        expect(subject.info.nickname).to eq(nickname)
+      end
+
+      it 'has the image from info' do
+        expect(subject.info.image).to eq(image)
+      end
+
+      it 'has the email from extra' do
+        expect(subject.extra.raw_info.email).to eq(email)
+      end
+
+      it 'has the username from extra' do
+        expect(subject.extra.raw_info.username).to eq(username)
+      end
+
+      it 'has the name from extra' do
+        expect(subject.extra.raw_info.name).to eq(name)
+      end
+
+      it 'has the nickname from extra' do
+        expect(subject.extra.raw_info.nickname).to eq(nickname)
+      end
+
+      it 'has the roles from extra' do
+        expect(subject.extra.raw_info.roles).to eq(roles)
+      end
+
+      it 'has the avatar from extra' do
+        expect(subject.extra.raw_info.avatar).to eq(image)
+      end
+
+      it 'has the profile from extra' do
+        expect(subject.extra.raw_info.profile).to eq(profile)
+      end
+
+      it 'has the country from extra' do
+        expect(subject.extra.raw_info.country).to eq(country)
+      end
+
+      it 'has the country_code from extra' do
+        expect(subject.extra.raw_info.country_code).to eq(country_code)
+      end
+
+      it 'has the postcode from extra' do
+        expect(subject.extra.raw_info.postcode).to eq(postcode)
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -122,7 +122,7 @@ RSpec.configure do |config|
 
   # Reset the RpiAuth config after each test
   config.after do
+    RpiAuth.configuration.disable_auth_bypass
     RpiAuth.configuration = RpiAuth::Configuration.new
-    OmniAuth.config.mock_auth.delete(:rpi)
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -120,8 +120,8 @@ RSpec.configure do |config|
   # as the one that triggered the failure.
   Kernel.srand config.seed
 
-  # Reset the RpiAuth config after each test
-  config.after do
+  # Reset the RpiAuth config before each test
+  config.before do
     RpiAuth.configuration.disable_auth_bypass
     RpiAuth.configuration = RpiAuth::Configuration.new
   end

--- a/spec/support/omniauth.rb
+++ b/spec/support/omniauth.rb
@@ -1,5 +1,3 @@
 # frozen_string_literal: true
 
 require 'omniauth'
-
-OmniAuth.config.test_mode = true

--- a/spec/support/request_helpers.rb
+++ b/spec/support/request_helpers.rb
@@ -2,6 +2,7 @@
 
 module RequestHelpers
   def stub_auth_for(user)
+    OmniAuth.config.test_mode = true
     OmniAuth.config.add_mock(:rpi, uid: user.user_id, extra: { raw_info: user.serializable_hash(except: :id) })
   end
 


### PR DESCRIPTION
## What's changed

* Removed omniauth-rpi
* Added omniauth_openid_connect 
* Added helper methods to RpiAuth::Configuration class to help set up the openid_connect client
* Adjusted how the tests were run to make sure OmniAuth test mode was toggled correctly
* Moved RpiAuthBypass + tests from omniauth-rpi to this gem
* Fixed up dummy app to work for local development.

## Points for consideration

I don't *think* any reconfiguration is necessary for clients to move from omniauth-rpi to omniauth_openid_connect thanks to the smoothing out performed in this gem.

The RpiAuthBypass is a bit.. rustic.   It has just been transplanted from omniauth-rpi, but I suspect the implementation could be refined to make it more useful, and less likely to breakage as Hydra / omniauth_openid_connect develop.  Ideally we'd have a check to make sure the auth hash it returns doesn't have extra fields compared to what hydra returns in the id token, etc.

This change allows us to use the JWKS client auth method, and more tightly verifies tokens returned by Hydra.