### PR TITLE
Release v3.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v2.1.0]
+
 ### Changed
 
 - Replaced usage of [omniauth-rpi](https://github.com/RaspberryPiFoundation/omniauth-rpi/) strategy with [omniauth_openid_connect](https://github.com/omniauth/omniauth_openid_connect/) (#51)
@@ -73,6 +75,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - callback, logout and failure routes to handle auth
 
 [Unreleased]: https://github.com/RaspberryPiFoundation/rpi-auth/compare/v1.4.0...HEAD
+[v2.1.0]: https://github.com/RaspberryPiFoundation/rpi-auth/releases/tag/v2.1.0
 [v2.0.0]: https://github.com/RaspberryPiFoundation/rpi-auth/releases/tag/v2.0.0
 [v1.4.0]: https://github.com/RaspberryPiFoundation/rpi-auth/releases/tag/v1.4.0
 [v1.3.0]: https://github.com/RaspberryPiFoundation/rpi-auth/releases/tag/v1.3.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [v2.1.0]
+## [v3.0.0]
 
 ### Changed
 
@@ -74,8 +74,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - rails model concern to allow host app to add auth behaviour to a model
 - callback, logout and failure routes to handle auth
 
-[Unreleased]: https://github.com/RaspberryPiFoundation/rpi-auth/compare/v1.4.0...HEAD
-[v2.1.0]: https://github.com/RaspberryPiFoundation/rpi-auth/releases/tag/v2.1.0
+[Unreleased]: https://github.com/RaspberryPiFoundation/rpi-auth/compare/v3.0.0...HEAD
+[v3.0.0]: https://github.com/RaspberryPiFoundation/rpi-auth/releases/tag/v3.0.0
 [v2.0.0]: https://github.com/RaspberryPiFoundation/rpi-auth/releases/tag/v2.0.0
 [v1.4.0]: https://github.com/RaspberryPiFoundation/rpi-auth/releases/tag/v1.4.0
 [v1.3.0]: https://github.com/RaspberryPiFoundation/rpi-auth/releases/tag/v1.3.0

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rpi_auth (2.1.0)
+    rpi_auth (3.0.0)
       omniauth-rails_csrf_protection (~> 1.0.0)
       omniauth_openid_connect (~> 0.7.1)
       rails (>= 6.1.4)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rpi_auth (2.0.0)
+    rpi_auth (2.1.0)
       omniauth-rails_csrf_protection (~> 1.0.0)
       omniauth_openid_connect (~> 0.7.1)
       rails (>= 6.1.4)

--- a/gemfiles/rails_6.1.gemfile.lock
+++ b/gemfiles/rails_6.1.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    rpi_auth (2.1.0)
+    rpi_auth (3.0.0)
       omniauth-rails_csrf_protection (~> 1.0.0)
       omniauth_openid_connect (~> 0.7.1)
       rails (>= 6.1.4)

--- a/gemfiles/rails_6.1.gemfile.lock
+++ b/gemfiles/rails_6.1.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    rpi_auth (2.0.0)
+    rpi_auth (2.1.0)
       omniauth-rails_csrf_protection (~> 1.0.0)
       omniauth_openid_connect (~> 0.7.1)
       rails (>= 6.1.4)
@@ -153,6 +153,8 @@ GEM
       byebug (~> 11.0)
       pry (>= 0.13, < 0.15)
     public_suffix (5.0.1)
+    puma (6.2.2)
+      nio4r (~> 2.0)
     racc (1.6.0)
     rack (2.2.4)
     rack-oauth2 (2.2.0)
@@ -286,6 +288,7 @@ PLATFORMS
 DEPENDENCIES
   listen
   pry-byebug
+  puma
   rails (~> 6.1)
   rpi_auth!
   rspec-rails

--- a/lib/rpi_auth/version.rb
+++ b/lib/rpi_auth/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module RpiAuth
-  VERSION = '2.0.0'
+  VERSION = '2.1.0'
 end

--- a/lib/rpi_auth/version.rb
+++ b/lib/rpi_auth/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module RpiAuth
-  VERSION = '2.1.0'
+  VERSION = '3.0.0'
 end


### PR DESCRIPTION
This is a major release, as we've replaced the underlying OmniAuth library, which might cause some implementation/usage changes.

### Changed

- Replaced usage of [omniauth-rpi](https://github.com/RaspberryPiFoundation/omniauth-rpi/) strategy with [omniauth_openid_connect](https://github.com/omniauth/omniauth_openid_connect/) (#51)
