### PR TITLE
Set redirect uri

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Ensure `redirect_uri` is set in the OpenID Connect configuration
+
 ## [v3.0.0]
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Ensure `redirect_uri` is set in the OpenID Connect configuration
+- Ensure `redirect_uri` is set in the OpenID Connect configuration (#53)
 
 ## [v3.0.0]
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,11 +4,9 @@ Rails.application.routes.draw do
   # Dummy routes. These routes are never reached in the app, as Omniauth
   # intercepts it via Rack middleware before it reaches Rails, however adding
   # them allows us to use rpi_auth_login_path helpers etc.
-  post '/auth/rpi', as: :rpi_auth_login, params: { login_options: 'v1_signup' }
-  post '/auth/rpi', as: :rpi_auth_signup, params: { login_options: 'force_signup,v1_signup' }
+  post RpiAuth::Engine::LOGIN_PATH, as: :rpi_auth_login, params: { login_options: 'v1_signup' }
+  post RpiAuth::Engine::LOGIN_PATH, as: :rpi_auth_signup, params: { login_options: 'force_signup,v1_signup' }
 
-  namespace 'rpi_auth' do
-    get '/auth/callback', to: 'auth#callback', as: 'callback'
-    get '/logout', to: 'auth#destroy', as: 'logout'
-  end
+  get RpiAuth::Engine::CALLBACK_PATH, to: 'rpi_auth/auth#callback', as: 'rpi_auth_callback'
+  get RpiAuth::Engine::LOGOUT_PATH, to: 'rpi_auth/auth#destroy', as: 'rpi_auth_logout'
 end

--- a/lib/rpi_auth/engine.rb
+++ b/lib/rpi_auth/engine.rb
@@ -9,6 +9,10 @@ module RpiAuth
 
     using ::RpiAuthBypass
 
+    LOGIN_PATH = '/auth/rpi'
+    CALLBACK_PATH = '/rpi_auth/auth/callback'
+    LOGOUT_PATH = '/rpi_auth/logout'
+
     initializer 'RpiAuth.set_logger' do
       OmniAuth.config.logger = Rails.logger
     end
@@ -22,7 +26,7 @@ module RpiAuth
           name: :rpi,
           issuer: RpiAuth.configuration.issuer,
           scope: RpiAuth.configuration.scope,
-          callback_path: '/rpi_auth/auth/callback',
+          callback_path: CALLBACK_PATH,
           response_type: RpiAuth.configuration.response_type,
           client_auth_method: RpiAuth.configuration.client_auth_method,
           client_options: {
@@ -34,7 +38,7 @@ module RpiAuth
             authorization_endpoint: RpiAuth.configuration.authorization_endpoint,
             token_endpoint: RpiAuth.configuration.token_endpoint,
             jwks_uri: RpiAuth.configuration.jwks_uri,
-            redirect_uri: URI.join(RpiAuth.configuration.host_url, '/rpi_auth/auth/callback')
+            redirect_uri: URI.join(RpiAuth.configuration.host_url, CALLBACK_PATH)
           },
           extra_authorize_params: { brand: RpiAuth.configuration.brand },
           allow_authorize_params: [:login_options],

--- a/lib/rpi_auth/engine.rb
+++ b/lib/rpi_auth/engine.rb
@@ -33,7 +33,8 @@ module RpiAuth
             port: RpiAuth.configuration.token_endpoint.port,
             authorization_endpoint: RpiAuth.configuration.authorization_endpoint,
             token_endpoint: RpiAuth.configuration.token_endpoint,
-            jwks_uri: RpiAuth.configuration.jwks_uri
+            jwks_uri: RpiAuth.configuration.jwks_uri,
+            redirect_uri: URI.join(RpiAuth.configuration.host_url, '/rpi_auth/auth/callback'),
           },
           extra_authorize_params: { brand: RpiAuth.configuration.brand },
           allow_authorize_params: [:login_options],

--- a/lib/rpi_auth/engine.rb
+++ b/lib/rpi_auth/engine.rb
@@ -34,7 +34,7 @@ module RpiAuth
             authorization_endpoint: RpiAuth.configuration.authorization_endpoint,
             token_endpoint: RpiAuth.configuration.token_endpoint,
             jwks_uri: RpiAuth.configuration.jwks_uri,
-            redirect_uri: URI.join(RpiAuth.configuration.host_url, '/rpi_auth/auth/callback'),
+            redirect_uri: URI.join(RpiAuth.configuration.host_url, '/rpi_auth/auth/callback')
           },
           extra_authorize_params: { brand: RpiAuth.configuration.brand },
           allow_authorize_params: [:login_options],

--- a/spec/dummy/config/initializers/rpi_auth.rb
+++ b/spec/dummy/config/initializers/rpi_auth.rb
@@ -10,8 +10,16 @@ RpiAuth.configure do |config|
 
   config.bypass_auth = false
 
-  # Profile is running in docker, so we need to set this manually.  This
-  # shouldn't be needed elsewhere, unless you're getting errors saying:
-  #   Invalid ID token: Issuer does not match
+  # In development, the issuer is set in the docker-compose.yml file in the
+  # Profile repo.  If you see errors like
+  #
+  #  (rpi) Authentication failure! Invalid ID token: Issuer does not match
+  #
+  # then set the issuer here to match the value in the docker-compose file.
+  # When Hydra is running, the issue value can also be viewed at
+  # http://localhost:9001/.well-known/openid-configuration
+  #
+  # In staging/production this shouldn't be an issue, as all the hostnames are
+  # the same.
   config.issuer = "http://localhost:9001/"
 end

--- a/spec/dummy/config/initializers/rpi_auth.rb
+++ b/spec/dummy/config/initializers/rpi_auth.rb
@@ -13,5 +13,5 @@ RpiAuth.configure do |config|
   # Profile is running in docker, so we need to set this manually.  This
   # shouldn't be needed elsewhere, unless you're getting errors saying:
   #   Invalid ID token: Issuer does not match
-  config.issuer = "http://host.docker.internal:9001/"
+  config.issuer = "http://localhost:9001/"
 end


### PR DESCRIPTION
When multiple redirect URIs are set in Hydra, it needs a redirect_uri param specifying.   I had assumed that the `callback_path` would be enough, but it turns out I was wrong.

This expeclicitly sets the redirect_uri parameter when initiating the login flow.