### PR TITLE
Update issuer value to default to the authorization_endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Altered default value of the `issuer` to track the `authorization_endpoint` rather than the `token_endpoint` (#54)
+
 ### Fixed
 
 - Ensure `redirect_uri` is set in the OpenID Connect configuration (#53)

--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ config.railties_order = [RpiAuth::Engine, :main_app, :all]
 
 ## Troubleshooting
 
-Diagnosing issues with OpenID Conenct can be tricky, so here are some things to try.
+Diagnosing issues with OpenID Connect can be tricky, so here are some things to try.
 
 ### Setting the token URL in development mode
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ RpiAuth.configure do |config|
 end
 ```
 
-The values above will allow you to login using the `gem-dev` client seeded in Hydra provided you run the host application on port `3009`.
+The values above will allow you to login using the `gem-dev` client seeded in Hydra provided you run the host application on port `3009`.  An example configuration can be found [in the dummy app](spec/dummy/config/initializers/rpi_auth.rb).
 
 You will need to change the values to match your application, ideally through ENV vars eg.
 
@@ -66,7 +66,7 @@ class ApplicationController < ActionController::Base
 end
 ```
 
-This provides access to the `current_user` method in controllers and helpers.
+This provides access to the `current_user` method in controllers and helpers.  The dummy app [has an example of this](spec/dummy/app/controllers/application_controller.rb).
 
 Add the `authenticatable` concern to the host application's User model:
 
@@ -76,7 +76,7 @@ class User < ApplicationRecord
 end
 ```
 
-This model needs to be the same one defined in the initializer, an instance will be created on login.
+This model needs to be the same one defined in the initializer, an instance will be created on login.  Again, checkout the [user model in the dummy app](spec/dummy/app/models/user.rb).
 
 To login via Hydra your app needs to send the user to `/auth/rpi` via a POST request:
 

--- a/lib/rpi_auth/configuration.rb
+++ b/lib/rpi_auth/configuration.rb
@@ -46,7 +46,7 @@ module RpiAuth
     end
 
     def issuer
-      @issuer ||= token_endpoint.merge('/').to_s
+      @issuer ||= authorization_endpoint.merge('/').to_s
     end
 
     def jwks_uri

--- a/spec/dummy/config/initializers/rpi_auth.rb
+++ b/spec/dummy/config/initializers/rpi_auth.rb
@@ -9,17 +9,4 @@ RpiAuth.configure do |config|
   config.user_model = 'User'
 
   config.bypass_auth = false
-
-  # In development, the issuer is set in the docker-compose.yml file in the
-  # Profile repo.  If you see errors like
-  #
-  #  (rpi) Authentication failure! Invalid ID token: Issuer does not match
-  #
-  # then set the issuer here to match the value in the docker-compose file.
-  # When Hydra is running, the issue value can also be viewed at
-  # http://localhost:9001/.well-known/openid-configuration
-  #
-  # In staging/production this shouldn't be an issue, as all the hostnames are
-  # the same.
-  config.issuer = "http://localhost:9001/"
 end

--- a/spec/rpi_auth/configuration_spec.rb
+++ b/spec/rpi_auth/configuration_spec.rb
@@ -64,14 +64,14 @@ RSpec.describe RpiAuth::Configuration do
       it 'sets the authorization_endpoint correctly' do
         expect(configuration.authorization_endpoint).to eq URI.parse(auth_url).merge('/oauth2/auth')
       end
+
+      it 'sets the issuer' do
+        expect(configuration.issuer).to eq URI.parse(expected_url).merge('/').to_s
+      end
     end
   end
 
   shared_examples 'sets up the token url defaults' do
-    it 'sets the issuer' do
-      expect(configuration.issuer).to eq URI.parse(expected_url).merge('/').to_s
-    end
-
     it 'sets the token_endpoint' do
       expect(configuration.token_endpoint).to eq URI.parse(expected_url).merge('/oauth2/token')
     end


### PR DESCRIPTION
I was confusing myself when running Hydra v1.11 (rather than v1.9) and decided that the issuer should be based on the `token_endpoint` rather than the `authorization_endpoint`. 

In 1.11 it is possible to specify the `SELF_PUBLIC_URL` value to split between URLs that should be queried by the browser, and those queried by the hydra client (ie.. the rails app).  This helps with discovery, but ends up with the `SELF_ISSUER_URL` being `docker.host.internal` such that the other endpoints are correctly set.

This PR simplifies things back to match with v1.9 😅 meaning that we don't have to see the issuer by hand.