### PR TITLE
Allow customising of the logout returnTo URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+-  Allow for customisation of returnTo param on log out (#56)
+
 ## [v3.1.0]
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -139,6 +139,16 @@ meaning (most) users will end up back on the page where they started the auth fl
 
 Finally, if none of these things are set, we end up back at the application root.
 
+#### Redirecting when logging out
+
+It is also possible to send users to pages within your app when logging out.  Just set the `returnTo` parameter again.
+
+```ruby
+link_to 'Log out', rpi_auth_logout_path, params: { returnTo: '/thanks-dude' }
+```
+
+This has to be a relative URL, i.e. it has to start with a slash.  This is to ensure there's no open redirect.
+
 ### Globbed/catch-all routes
 
 If your app has a catch-all route at the end of the routing table, you must

--- a/app/controllers/rpi_auth/auth_controller.rb
+++ b/app/controllers/rpi_auth/auth_controller.rb
@@ -17,20 +17,18 @@ module RpiAuth
       self.current_user = RpiAuth.user_model.from_omniauth(auth)
 
       redirect_to RpiAuth.configuration.success_redirect.presence ||
-                  request.env.fetch('omniauth.origin', nil).presence ||
-                  '/'
+                  ensure_relative_url(request.env['omniauth.origin'])
     end
 
     def destroy
       reset_session
 
-      # Prevent redirect loops etc.
-      if RpiAuth.configuration.bypass_auth == true
-        redirect_to '/'
-        return
-      end
+      # Any redirect must be within our app, so it should start with a slash.
+      return_to = ensure_relative_url(params[:returnTo])
 
-      redirect_to "#{RpiAuth.configuration.identity_url}/logout?returnTo=#{RpiAuth.configuration.host_url}",
+      return redirect_to return_to if RpiAuth.configuration.bypass_auth == true
+
+      redirect_to "#{RpiAuth.configuration.identity_url}/logout?returnTo=#{RpiAuth.configuration.host_url}#{return_to}",
                   allow_other_host: true
     end
 
@@ -41,6 +39,23 @@ module RpiAuth
                         'Login error'
                       end
       redirect_to '/'
+    end
+
+    private
+
+    def ensure_relative_url(url)
+      url = URI.parse(url)
+
+      # Bail out early if the URL doesn't look local. This condition is taken
+      # from ActionController::Redirecting#_url_host_allowed? in Rails 7.0
+      raise ArgumentError unless url.host == request.host || (url.host.nil? && url.to_s.start_with?('/'))
+
+      # This is a bit of an odd way to do things, but it means that this method
+      # works with both URI::Generic and URI::HTTP
+      relative_url = [url.path, url.query].compact.join('?')
+      [relative_url, url.fragment].compact.join('#')
+    rescue ArgumentError, URI::Error
+      '/'
     end
   end
 end

--- a/spec/dummy/spec/requests/auth_request_spec.rb
+++ b/spec/dummy/spec/requests/auth_request_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe 'Authentication' do
 
   let(:bypass_auth) { false }
   let(:identity_url) { 'https://my.example.com' }
-  # We need to make sure we match the hostname Rails uses in test requests 
+  # We need to make sure we match the hostname Rails uses in test requests
   # here, otherwise `returnTo` redirects will fail after login/logout.
   let(:host_url) { 'https://www.example.com' }
 

--- a/spec/dummy/spec/requests/auth_request_spec.rb
+++ b/spec/dummy/spec/requests/auth_request_spec.rb
@@ -17,6 +17,8 @@ RSpec.describe 'Authentication' do
 
   let(:bypass_auth) { false }
   let(:identity_url) { 'https://my.example.com' }
+  # We need to make sure we match the hostname Rails uses in test requests 
+  # here, otherwise `returnTo` redirects will fail after login/logout.
   let(:host_url) { 'https://www.example.com' }
 
   before do


### PR DESCRIPTION
Closes #46 

## What's changed

* A returnTo parameter can be added to the logout path to redirect users to a different place having logged out.
* Altered how we handle returnTo parameters in general, as Rails 6 doesn't check for open redirects