### PR TITLE
Add country to Authenticable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add country attribute to `Authenticable` (#60)
+
 ## [v3.2.0]
 
 ### Added

--- a/lib/rpi_auth/models/authenticatable.rb
+++ b/lib/rpi_auth/models/authenticatable.rb
@@ -6,6 +6,7 @@ module RpiAuth
       extend ActiveSupport::Concern
 
       PROFILE_KEYS = %w[
+        country
         country_code
         email
         email_verified

--- a/spec/rpi_auth/models/authenticatable_spec.rb
+++ b/spec/rpi_auth/models/authenticatable_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe DummyUser, type: :model do
   subject { described_class.new }
 
   it { is_expected.to respond_to(:user_id) }
+  it { is_expected.to respond_to(:country) }
   it { is_expected.to respond_to(:country_code) }
   it { is_expected.to respond_to(:email) }
   it { is_expected.to respond_to(:name) }
@@ -32,6 +33,7 @@ RSpec.describe DummyUser, type: :model do
         email: 'test@example.com',
         name: 'Bodkin Van Horn',
         nickname: 'Hoos-Foos',
+        country: 'Zimbabwe',
         country_code: 'ZW',
         picture: 'https://placecage.com/100/100',
         profile: 'https://my.raspberry.pi/profile/edit'
@@ -56,6 +58,7 @@ RSpec.describe DummyUser, type: :model do
       expect(omniauth_user.name).to eq('Bodkin Van Horn')
       expect(omniauth_user.nickname).to eq('Hoos-Foos')
       expect(omniauth_user.email).to eq('test@example.com')
+      expect(omniauth_user.country).to eq('Zimbabwe')
       expect(omniauth_user.country_code).to eq('ZW')
       expect(omniauth_user.picture).to eq('https://placecage.com/100/100')
       expect(omniauth_user.profile).to eq('https://my.raspberry.pi/profile/edit')

--- a/spec/rpi_auth/models/authenticatable_spec.rb
+++ b/spec/rpi_auth/models/authenticatable_spec.rb
@@ -54,14 +54,14 @@ RSpec.describe DummyUser, type: :model do
 
     it 'returns a user with the correct attributes' do
       expect(omniauth_user).to be_a described_class
-      expect(omniauth_user.user_id).to eq('testuserid')
-      expect(omniauth_user.name).to eq('Bodkin Van Horn')
-      expect(omniauth_user.nickname).to eq('Hoos-Foos')
-      expect(omniauth_user.email).to eq('test@example.com')
-      expect(omniauth_user.country).to eq('Zimbabwe')
-      expect(omniauth_user.country_code).to eq('ZW')
-      expect(omniauth_user.picture).to eq('https://placecage.com/100/100')
-      expect(omniauth_user.profile).to eq('https://my.raspberry.pi/profile/edit')
+      expect(omniauth_user).to have_attributes(user_id: 'testuserid',
+                                               name: 'Bodkin Van Horn',
+                                               nickname: 'Hoos-Foos',
+                                               email: 'test@example.com',
+                                               country: 'Zimbabwe',
+                                               country_code: 'ZW',
+                                               picture: 'https://placecage.com/100/100',
+                                               profile: 'https://my.raspberry.pi/profile/edit')
     end
 
     context 'with unusual keys in info' do

--- a/spec/rpi_auth/models/authenticatable_spec.rb
+++ b/spec/rpi_auth/models/authenticatable_spec.rb
@@ -54,12 +54,9 @@ RSpec.describe DummyUser, type: :model do
 
     it 'returns a user with the correct attributes' do
       expect(omniauth_user).to be_a described_class
-      expect(omniauth_user).to have_attributes(user_id: 'testuserid',
-                                               name: 'Bodkin Van Horn',
-                                               nickname: 'Hoos-Foos',
-                                               email: 'test@example.com',
-                                               country: 'Zimbabwe',
-                                               country_code: 'ZW',
+      expect(omniauth_user).to have_attributes(user_id: 'testuserid', name: 'Bodkin Van Horn',
+                                               nickname: 'Hoos-Foos', email: 'test@example.com',
+                                               country: 'Zimbabwe', country_code: 'ZW',
                                                picture: 'https://placecage.com/100/100',
                                                profile: 'https://my.raspberry.pi/profile/edit')
     end


### PR DESCRIPTION
Add `#country` as an attribute in `Authenticable`.

This is to support work in experience-ai, see https://github.com/RaspberryPiFoundation/experience-ai/issues/205