### PR TITLE
Removes v1_signup param

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,8 +4,8 @@ Rails.application.routes.draw do
   # Dummy routes. These routes are never reached in the app, as Omniauth
   # intercepts it via Rack middleware before it reaches Rails, however adding
   # them allows us to use rpi_auth_login_path helpers etc.
-  post RpiAuth::Engine::LOGIN_PATH, as: :rpi_auth_login, params: { login_options: 'v1_signup' }
-  post RpiAuth::Engine::LOGIN_PATH, as: :rpi_auth_signup, params: { login_options: 'force_signup,v1_signup' }
+  post RpiAuth::Engine::LOGIN_PATH, as: :rpi_auth_login
+  post RpiAuth::Engine::LOGIN_PATH, as: :rpi_auth_signup, params: { login_options: 'force_signup' }
 
   get RpiAuth::Engine::CALLBACK_PATH, to: 'rpi_auth/auth#callback', as: 'rpi_auth_callback'
   get RpiAuth::Engine::LOGOUT_PATH, to: 'rpi_auth/auth#destroy', as: 'rpi_auth_logout'

--- a/spec/dummy/spec/views/home_show_spec.rb
+++ b/spec/dummy/spec/views/home_show_spec.rb
@@ -17,12 +17,12 @@ RSpec.describe 'home/show' do
 
     it 'shows the correct log in link' do
       render
-      expect(html.search('form[action="/auth/rpi?login_options=v1_signup"]')).not_to be_empty
+      expect(html.search('form[action="/auth/rpi"]')).not_to be_empty
     end
 
     it 'shows the sign up link' do
       render
-      expect(html.search('form[action="/auth/rpi?login_options=force_signup%2Cv1_signup"]')).not_to be_empty
+      expect(html.search('form[action="/auth/rpi?login_options=force_signup"]')).not_to be_empty
     end
   end
 


### PR DESCRIPTION
No longer needed, since we now assume all log in / sign ups to Profile should use the v1 flow (since migrating fully to Hydra v1).

Depends on: https://github.com/RaspberryPiFoundation/profile/pull/1512