### PR TITLE
Profile OpenAPI client PoC

### DIFF
--- a/app/controllers/rpi_auth/auth_controller.rb
+++ b/app/controllers/rpi_auth/auth_controller.rb
@@ -1,10 +1,12 @@
 # frozen_string_literal: true
 
 require 'rpi_auth/controllers/current_user'
+require 'rpi_auth/controllers/profile_api_client'
 
 module RpiAuth
   class AuthController < ActionController::Base
     include RpiAuth::Controllers::CurrentUser
+    include RpiAuth::Controllers::ProfileApiClient
 
     protect_from_forgery with: :null_session
 
@@ -25,6 +27,31 @@ module RpiAuth
       end
 
       auth = request.env['omniauth.auth']
+      puts '******************'
+      puts auth
+      puts '******************'
+      # puts RpiAuth.openapi_client
+      # puts '******************'
+
+      if RpiAuth.configuration.profile_api_class
+        # OpenapiClient.configure do |config|
+        #   # Configure OAuth2 access token for authorization: oidc
+        #   config.access_token = auth.credentials.token
+        #   config.scheme = 'http'
+        #   config.host = 'host.docker.internal:3002'
+        #   # Configure a proc to get access tokens in lieu of the static access_token configuration
+        #   # config.access_token_getter = -> { 'YOUR TOKEN GETTER PROC' } 
+        # end
+        
+        self.profile_api_client_config = {
+          access_token: auth.credentials.token,
+          refresh_token: auth.credentials.refresh_token,
+        }
+        puts '******************'
+        puts self.profile_api_client
+        puts '******************'
+        puts self.profile_api_client.userinfo_get
+      end
       self.current_user = RpiAuth.user_model.from_omniauth(auth)
 
       redirect_to ensure_relative_url(login_redirect_path)

--- a/lib/rpi_auth/configuration.rb
+++ b/lib/rpi_auth/configuration.rb
@@ -18,7 +18,10 @@ module RpiAuth
                   :scope,
                   :session_keys_to_persist,
                   :success_redirect,
-                  :user_model
+                  :user_model,
+                  :profile_api_class,
+                  :profile_api_host,
+                  :profile_api_scheme
 
     def initialize
       @bypass_auth = false

--- a/lib/rpi_auth/controllers/profile_api_client.rb
+++ b/lib/rpi_auth/controllers/profile_api_client.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+module RpiAuth
+  module Controllers
+    module ProfileApiClient
+      extend ActiveSupport::Concern
+
+      included do
+        helper_method :profile_api_client
+      end
+
+      def profile_api_client
+        return @profile_api_client if @profile_api_client
+        return nil unless session[:profile_api_client_config]
+
+        puts '******************'
+        puts 'Creating new client'
+        puts '******************'
+
+        RpiAuth.configuration.profile_api_class.configure do |config|
+          config.scheme = RpiAuth.configuration.profile_api_scheme
+          config.host = RpiAuth.configuration.profile_api_host
+          # Configure a proc to get access tokens in lieu of the static access_token configuration
+          config.access_token_getter = -> {
+            refresh_access_token if access_token_expired?
+
+            profile_api_client_config['access_token']
+          } 
+        end
+
+        @profile_api_client = RpiAuth.configuration.profile_api_class::DefaultApi.new
+        @profile_api_client
+      end
+
+      def profile_api_client_config=(config)
+        session[:profile_api_client_config] = config.transform_keys(&:to_s)
+      end
+
+      def profile_api_client_config
+        return nil unless session[:profile_api_client_config]
+
+        session[:profile_api_client_config]
+      end
+
+      def refresh_access_token
+        request_time = Time.now.to_i
+        req = Net::HTTP::Post.new(RpiAuth.configuration.token_endpoint)
+        req.set_form_data(
+          grant_type: 'refresh_token',
+          refresh_token: profile_api_client_config['refresh_token'],
+        )
+        req.basic_auth(
+          RpiAuth.configuration.auth_client_id,
+          RpiAuth.configuration.auth_client_secret,
+        )
+        res = Net::HTTP.start(RpiAuth.configuration.token_endpoint.hostname, RpiAuth.configuration.token_endpoint.port) { |http| http.request(req) }
+        json = JSON.parse(res.body)
+        profile_api_client_config['access_token'] = json['access_token']
+        profile_api_client_config['expires_at'] = request_time + json['expires_in']
+        profile_api_client_config['refresh_token'] = json['refresh_token']
+      end
+
+      def access_token_expired?
+        return true if profile_api_client_config['expires_at'].nil?
+
+        Time.now.to_i > profile_api_client_config['expires_at']
+      end
+    end
+  end
+end


### PR DESCRIPTION
Proof of concept to auto-initialise an API client generated by https://github.com/OpenAPITools/openapi-generator

Takes the class of the generated client in as config, and uses the refresh token provided to generate new access tokens when needed so having access to the profile API can be done with some config to `rpi-auth`