### PR TITLE
new versions for github actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,6 +36,7 @@ jobs:
       with:
         name: code-coverage-report-ruby_${{ matrix.ruby-version }}-${{ matrix.gemfile }}
         path: ${{ github.workspace }}/coverage/
+        include-hidden-files: true
 
   post_coverage:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,7 +36,6 @@ jobs:
       with:
         name: code-coverage-report-ruby_${{ matrix.ruby-version }}-${{ matrix.gemfile }}
         path: ${{ github.workspace }}/coverage/
-        include-hidden-files: true
 
   post_coverage:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
     env:
       BUNDLE_GEMFILE: ${{ github.workspace }}/gemfiles/${{ matrix.gemfile }}.gemfile
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
@@ -32,10 +32,11 @@ jobs:
 
     - name: Archive coverage
       if: ${{ success() || failure() }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: code-coverage-report-ruby_${{ matrix.ruby-version }}-${{ matrix.gemfile }}
         path: ${{ github.workspace }}/coverage/
+        include-hidden-files: true
 
   post_coverage:
     runs-on: ubuntu-latest
@@ -43,7 +44,7 @@ jobs:
     permissions:
       pull-requests: write
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: code-coverage-report-ruby_3.2-rails_7.1
           path: coverage/


### PR DESCRIPTION
Update the versions of some github actions to stop using the deprecated versions. HIdden files are now excluded by default so allowed them in the upload to get the `.last_run.json` needed included.