### PR TITLE
Avoid LoadError when using rake

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -2,6 +2,4 @@
 
 require 'bundler/setup'
 
-load 'rails/tasks/statistics.rake'
-
 require 'bundler/gem_tasks'


### PR DESCRIPTION
Previously it wasn't even possible to list the rake tasks, because this `rails/tasks/statistics.rake` file does not exist.

It was added in [a very large initial commit][1] which doesn't mention it in the commit note, so I have no idea what its origins are.

[1]: https://github.com/RaspberryPiFoundation/rpi-auth/commit/79600c924364ecf9edcd05800739b2b193708ac1