### PR TITLE
Release v4.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Load error when using Rake (#77)
+- Don't use cached user if session has been reset (#79)
 
 ### Removed
 - Support for Ruby 2.7 (#78)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+
+### Fixed
+
+### Removed
+
+## [v4.0.0]
+
+### Added
 - Support for Ruby 3.3 (#78)
 
 ### Fixed
@@ -124,7 +132,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - rails model concern to allow host app to add auth behaviour to a model
 - callback, logout and failure routes to handle auth
 
-[Unreleased]: https://github.com/RaspberryPiFoundation/rpi-auth/compare/v3.6.0...HEAD
+[Unreleased]: https://github.com/RaspberryPiFoundation/rpi-auth/compare/v4.0.0...HEAD
+[v4.0.0]: https://github.com/RaspberryPiFoundation/rpi-auth/releases/tag/v4.0.0
 [v3.6.0]: https://github.com/RaspberryPiFoundation/rpi-auth/releases/tag/v3.6.0
 [v3.5.0]: https://github.com/RaspberryPiFoundation/rpi-auth/releases/tag/v3.5.0
 [v3.4.0]: https://github.com/RaspberryPiFoundation/rpi-auth/releases/tag/v3.4.0

--- a/gemfiles/rails_6.1.gemfile.lock
+++ b/gemfiles/rails_6.1.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    rpi_auth (3.6.0)
+    rpi_auth (4.0.0)
       omniauth-rails_csrf_protection (~> 1.0.0)
       omniauth_openid_connect (~> 0.7.1)
       rails (>= 6.1.4)

--- a/gemfiles/rails_7.0.gemfile.lock
+++ b/gemfiles/rails_7.0.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    rpi_auth (3.6.0)
+    rpi_auth (4.0.0)
       omniauth-rails_csrf_protection (~> 1.0.0)
       omniauth_openid_connect (~> 0.7.1)
       rails (>= 6.1.4)

--- a/gemfiles/rails_7.1.gemfile.lock
+++ b/gemfiles/rails_7.1.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    rpi_auth (3.6.0)
+    rpi_auth (4.0.0)
       omniauth-rails_csrf_protection (~> 1.0.0)
       omniauth_openid_connect (~> 0.7.1)
       rails (>= 6.1.4)

--- a/gemfiles/rails_7.2.gemfile.lock
+++ b/gemfiles/rails_7.2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    rpi_auth (3.6.0)
+    rpi_auth (4.0.0)
       omniauth-rails_csrf_protection (~> 1.0.0)
       omniauth_openid_connect (~> 0.7.1)
       rails (>= 6.1.4)

--- a/lib/rpi_auth/version.rb
+++ b/lib/rpi_auth/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module RpiAuth
-  VERSION = '3.6.0'
+  VERSION = '4.0.0'
 end


### PR DESCRIPTION
- [Add `CHANGELOG` entry for #79](https://github.com/RaspberryPiFoundation/rpi-auth/commit/00004283d0e9dc8a75cc813ef5ef7d3ea109b8f5)
- [Update `CHANGELOG` & `RpiAuth::VERSION` in preparation to release v4.0.0](https://github.com/RaspberryPiFoundation/rpi-auth/commit/7a82a3002d4e27dfa385be5994fa481ad982f555)