### PR TITLE
Add rubocop to CI build

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,12 +22,18 @@ jobs:
       BUNDLE_GEMFILE: ${{ github.workspace }}/gemfiles/${{ matrix.gemfile }}.gemfile
     steps:
     - uses: actions/checkout@v3
+
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby-version }}
         rubygems: 3.4.10
         bundler-cache: true # runs 'bundle install' and caches installed gems automatically
+
+    - name: Run linter
+      if: matrix.ruby-version == '3.3' && matrix.gemfile == 'rails_7.2'
+      run: bundle exec rubocop
+
     - name: Run tests
       run: bundle exec rspec
 

--- a/lib/rpi_auth/spec_helpers.rb
+++ b/lib/rpi_auth/spec_helpers.rb
@@ -5,7 +5,7 @@ module RpiAuth
     # This sets up the OmniAuth mock for the given user.  It assumes the User
     # model has an `:user_id` method which returns the users ID, but this can
     # be changed by setting the `id_param` option.
-    def stub_auth_for(user:, id_param: :user_id) # rubocop:disable Metrics/AbcSize
+    def stub_auth_for(user:, id_param: :user_id)
       expires_at = user.respond_to?(:expires_at) && user.expires_at
       expires_in = expires_at.present? ? expires_at.to_i - Time.zone.now.to_i : 3600
       token = user.respond_to?(:access_token) ? user.access_token : SecureRandom.hex(16)

--- a/spec/dummy/spec/requests/auth_request_spec.rb
+++ b/spec/dummy/spec/requests/auth_request_spec.rb
@@ -265,7 +265,7 @@ RSpec.describe 'Authentication' do
           expect(response).to redirect_to('/')
         end
 
-        context 'when the proc resolves to something other than nil' do # rubocop:disable RSpec/NestedGroups
+        context 'when the proc resolves to something other than nil' do
           # We use `current_user` and `request.env` here as they're available
           # in the context of the controller.  We use `let!` to make sure the
           # proc is defined straightaway, rather than later, when `request` and
@@ -283,7 +283,7 @@ RSpec.describe 'Authentication' do
           end
         end
 
-        context 'when the proc raises an exception' do # rubocop:disable RSpec/NestedGroups
+        context 'when the proc raises an exception' do
           # We use `current_user` and `request.env` here as they're available
           # in the context of the controller.  We use `let!` to make sure the
           # proc is defined straightaway, rather than later, when `request` and


### PR DESCRIPTION
This fixes some existing rubocop violations via the auto-correct mechanism and then adds rubocop to the CI build as an extra step in the "test" job, but only executing for Ruby v3.3 and Rails v7.2 (currently the latest version of each being tested).