### PR TITLE
Fix requiring of oauth2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+## [v4.1.1]
+
+### Fixed
+
+- Fix requiring of oauth2 to avoid `NoMethodError: undefined method 'config' for module OAuth2` (#86)
+
 ## [v4.1.0]
 
 ### Added
@@ -140,7 +146,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - rails model concern to allow host app to add auth behaviour to a model
 - callback, logout and failure routes to handle auth
 
-[Unreleased]: https://github.com/RaspberryPiFoundation/rpi-auth/compare/v4.1.0...HEAD
+[Unreleased]: https://github.com/RaspberryPiFoundation/rpi-auth/compare/v4.1.1...HEAD
+[v4.1.1]: https://github.com/RaspberryPiFoundation/rpi-auth/releases/tag/v4.1.1
 [v4.1.0]: https://github.com/RaspberryPiFoundation/rpi-auth/releases/tag/v4.1.0
 [v4.0.0]: https://github.com/RaspberryPiFoundation/rpi-auth/releases/tag/v4.0.0
 [v3.6.0]: https://github.com/RaspberryPiFoundation/rpi-auth/releases/tag/v3.6.0

--- a/gemfiles/rails_6.1.gemfile.lock
+++ b/gemfiles/rails_6.1.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    rpi_auth (4.1.0)
+    rpi_auth (4.1.1)
       oauth2
       omniauth-rails_csrf_protection (~> 1.0.0)
       omniauth_openid_connect (~> 0.7.1)

--- a/gemfiles/rails_7.0.gemfile.lock
+++ b/gemfiles/rails_7.0.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    rpi_auth (4.1.0)
+    rpi_auth (4.1.1)
       oauth2
       omniauth-rails_csrf_protection (~> 1.0.0)
       omniauth_openid_connect (~> 0.7.1)

--- a/gemfiles/rails_7.1.gemfile.lock
+++ b/gemfiles/rails_7.1.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    rpi_auth (4.1.0)
+    rpi_auth (4.1.1)
       oauth2
       omniauth-rails_csrf_protection (~> 1.0.0)
       omniauth_openid_connect (~> 0.7.1)

--- a/gemfiles/rails_7.2.gemfile.lock
+++ b/gemfiles/rails_7.2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    rpi_auth (4.1.0)
+    rpi_auth (4.1.1)
       oauth2
       omniauth-rails_csrf_protection (~> 1.0.0)
       omniauth_openid_connect (~> 0.7.1)

--- a/lib/rpi_auth/controllers/auto_refreshing_token.rb
+++ b/lib/rpi_auth/controllers/auto_refreshing_token.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'oauth2/error'
+require 'oauth2'
 
 module RpiAuth
   module Controllers

--- a/lib/rpi_auth/oauth_client.rb
+++ b/lib/rpi_auth/oauth_client.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
-require 'oauth2/client'
-require 'oauth2/access_token'
+require 'oauth2'
 
 module RpiAuth
   class OauthClient

--- a/lib/rpi_auth/version.rb
+++ b/lib/rpi_auth/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module RpiAuth
-  VERSION = '4.1.0'
+  VERSION = '4.1.1'
 end

--- a/spec/dummy/spec/requests/refresh_credentials_spec.rb
+++ b/spec/dummy/spec/requests/refresh_credentials_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-require 'oauth2/error'
+require 'oauth2'
 
 RSpec.describe 'Refreshing the auth token', type: :request do
   include ActiveSupport::Testing::TimeHelpers

--- a/spec/rpi_auth/oauth_client_spec.rb
+++ b/spec/rpi_auth/oauth_client_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
-require 'oauth2'
 
 RSpec.describe RpiAuth::OauthClient do
   include ActiveSupport::Testing::TimeHelpers


### PR DESCRIPTION
The changes in #83 (which were released in v4.1.0) moved the `OauthClient` class (which uses the `oauth2` gem) from the Rails applications into the `rpi_auth` gem. At that point the `oauth2` gem was made a direct dependency of `rpi_auth` and the direct dependency on `oauth2` was removed from the Rails applications.

I _think_ this meant that the `oauth2` gem was no longer being required automatically. And, although individual files in the `oauth2` gem were being required from individual files in `rpi_auth`, this meant that not all of the files in `oauth2` were being required. In particular, the `lib/oauth2.rb` file which defines the top-level `OAuth2` module and the `OAuth2.config` method was no longer being required. This led to exceptions like [this one][1] in `experience-cs` when
`RpiAuth::OauthClient#refresh_credentials` was called:

    NoMethodError: undefined method 'config' for module OAuth2

This commit changes the require statements to just require `oauth2` which in turn [requires all the relevant files][2] in the `oauth2` gem. The require statement in `spec/rpi_auth/oauth_client_spec.rb` is unnecessary, because it's automatically loading `RpiAuth::OauthClient` which in turn loads `oauth2`. This should mean we no longer see exceptions like the one above.

I've tested that this fix works in `experience-cs` in https://github.com/RaspberryPiFoundation/experience-cs/pull/421 - I ran the Rails app and triggered a token refresh to check that `NoMethodError` was no longer being raised.

[1]: https://raspberrypifoundation.sentry.io/issues/6590882516?project=4508953237651456
[2]: https://gitlab.com/oauth-xx/oauth2/-/blob/v2.0.9/lib/oauth2.rb?ref_type=tags#L11-23