### PR TITLE
Prepare to release v4.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+## [v4.2.0]
+
+### Added
+
+- Allow OmniAuth setup phase to be configured (#76)
+- Add `RpiAuth::Models::Roles#parsed_roles` (extracted from experience-cs) (#87)
+- Add `RpiAuth::Models::AccountTypes#student_account?` (extracted from experience-cs) (#87)
+
 ## [v4.1.1]
 
 ### Fixed
@@ -146,7 +154,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - rails model concern to allow host app to add auth behaviour to a model
 - callback, logout and failure routes to handle auth
 
-[Unreleased]: https://github.com/RaspberryPiFoundation/rpi-auth/compare/v4.1.1...HEAD
+[Unreleased]: https://github.com/RaspberryPiFoundation/rpi-auth/compare/v4.2.0...HEAD
+[v4.2.0]: https://github.com/RaspberryPiFoundation/rpi-auth/releases/tag/v4.2.0
 [v4.1.1]: https://github.com/RaspberryPiFoundation/rpi-auth/releases/tag/v4.1.1
 [v4.1.0]: https://github.com/RaspberryPiFoundation/rpi-auth/releases/tag/v4.1.0
 [v4.0.0]: https://github.com/RaspberryPiFoundation/rpi-auth/releases/tag/v4.0.0

--- a/gemfiles/rails_6.1.gemfile.lock
+++ b/gemfiles/rails_6.1.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    rpi_auth (4.1.1)
+    rpi_auth (4.2.0)
       oauth2
       omniauth-rails_csrf_protection (~> 1.0.0)
       omniauth_openid_connect (~> 0.7.1)

--- a/gemfiles/rails_7.0.gemfile.lock
+++ b/gemfiles/rails_7.0.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    rpi_auth (4.1.1)
+    rpi_auth (4.2.0)
       oauth2
       omniauth-rails_csrf_protection (~> 1.0.0)
       omniauth_openid_connect (~> 0.7.1)

--- a/gemfiles/rails_7.1.gemfile.lock
+++ b/gemfiles/rails_7.1.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    rpi_auth (4.1.1)
+    rpi_auth (4.2.0)
       oauth2
       omniauth-rails_csrf_protection (~> 1.0.0)
       omniauth_openid_connect (~> 0.7.1)

--- a/gemfiles/rails_7.2.gemfile.lock
+++ b/gemfiles/rails_7.2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    rpi_auth (4.1.1)
+    rpi_auth (4.2.0)
       oauth2
       omniauth-rails_csrf_protection (~> 1.0.0)
       omniauth_openid_connect (~> 0.7.1)

--- a/lib/rpi_auth/version.rb
+++ b/lib/rpi_auth/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module RpiAuth
-  VERSION = '4.1.1'
+  VERSION = '4.2.0'
 end


### PR DESCRIPTION
Since this adds new functionality in a backward compatible manner, it makes sense for it to be a minor version bump from v4.1.1 -> v4.2.0.

I've split #87 into two lines in the CHANGELOG for clarity.

I've only included the version change of them gem itself in the Gemfile changes; I discarded changes in versions of other gems which just seemed to be because the dependencies are unconstrained and they are not needed for the changes in this release.