### PR TITLE
Return boolean from `AccountTypes#student_account?`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Return boolean from `AccountTypes#student_account?` (#91)
+
 ### Removed
 
 ## [v4.2.1]

--- a/lib/rpi_auth/models/account_types.rb
+++ b/lib/rpi_auth/models/account_types.rb
@@ -10,7 +10,9 @@ module RpiAuth
       include Authenticatable
 
       def student_account?
-        user_id =~ /^#{STUDENT_PREFIX}/o
+        return false if user_id.blank?
+
+        user_id.start_with?(STUDENT_PREFIX)
       end
     end
   end

--- a/spec/rpi_auth/models/account_types_spec.rb
+++ b/spec/rpi_auth/models/account_types_spec.rb
@@ -16,16 +16,24 @@ RSpec.describe RpiAuth::Models::AccountTypes, type: :model do
     context "when user_id has the 'student:' prefix" do
       let(:user_id) { RpiAuth::Models::AccountTypes::STUDENT_PREFIX + SecureRandom.uuid }
 
-      it 'returns truthy' do
-        expect(user).to be_student_account
+      it 'returns true' do
+        expect(user.student_account?).to be(true)
       end
     end
 
     context "when user_id does not have the 'student:' prefix" do
       let(:user_id) { SecureRandom.uuid }
 
-      it 'returns falsey' do
-        expect(user).not_to be_student_account
+      it 'returns false' do
+        expect(user.student_account?).to be(false)
+      end
+    end
+
+    context 'when user_id is not set' do
+      let(:user_id) { nil }
+
+      it 'returns false' do
+        expect(user.student_account?).to be(false)
       end
     end
   end


### PR DESCRIPTION
Previously this method returned either `0` or `nil`. This works fine in Ruby, because `0` is truth-y, but it causes problems if you want to persist the value in a Postgres boolean type, because `0` is cast to `FALSE`. The new implementation always returns either `true` or `false`.

This will mean we can remove [this workaround][1] in `experience-cs`.

[1]: https://github.com/RaspberryPiFoundation/experience-cs/commit/130592b833509a52aac1511bb17320a4d7eadeb4